### PR TITLE
add basic support for Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,58 @@
+dist: trusty
+
+os: linux
+
+language: cpp
+
+env:
+  global:
+    - PREFIX="${HOME}/opt"
+    - ASIO_VERSION="862aed305dcf91387535519c9549c17630339a12"
+    - LZ4_VERSION="1.7.5"
+    - MBEDTLS_VERSION="2.5.1"
+    - MBEDTLS_CFLAGS="-I${PREFIX}/include"
+    - MBEDTLS_LIBS="-lmbedtls -lmbedx509 -lmbedcrypto"
+    - OPENSSL_VERSION="1.0.2l"
+    - OPENSSL_CFLAGS="-I${PREFIX}/include"
+    - OPENSSL_LIBS="-lssl -lcrypto"
+
+matrix:
+  include:
+    - env: SSLLIB="openssl"
+      os: osx
+      osx_image: xcode8.3
+      compiler: clang
+    - env: SSLLIB="mbedtls"
+      os: osx
+      osx_image: xcode8.3
+      compiler: clang
+    - env: SSLLIB="openssl"
+      os: linux
+      compiler: gcc
+    - env: SSLLIB="openssl"
+      os: linux
+      compiler: clang
+    - env: SSLLIB="mbedtls"
+      os: linux
+      compiler: gcc
+    - env: SSLLIB="mbedtls"
+      os: linux
+      compiler: clang
+
+addons:
+  apt:
+    packages:
+      - libboost-all-dev
+      - linux-libc-dev
+
+cache:
+  ccache: true
+  directories:
+  - download-cache
+  - ${HOME}/opt
+
+install:
+  - .travis/build-deps.sh
+
+script:
+  - .travis/build-check.sh

--- a/.travis/build-check.sh
+++ b/.travis/build-check.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+set -eux
+
+PREFIX="${PREFIX:-${HOME}/opt}"
+
+if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+    export LD_LIBRARY_PATH="${PREFIX}/lib:${LD_LIBRARY_PATH:-}"
+fi
+
+if [ "${TRAVIS_OS_NAME}" = "osx"   ]; then
+    export DYLD_LIBRARY_PATH="${PREFIX}/lib:${DYLD_LIBRARY_PATH:-}"
+fi
+
+
+if [ "${SSLLIB}" = "openssl" ]; then
+    SSL_LIBS="${OPENSSL_LIBS}"
+    SSL_CFLAGS="-DUSE_OPENSSL"
+elif [ "${SSLLIB}" = "mbedtls" ]; then
+    SSL_LIBS="${MBEDTLS_LIBS}"
+    SSL_CFLAGS="-DUSE_MBEDTLS"
+else
+    echo "Invalid crypto lib: ${SSLLIB}"
+    exit 1
+fi
+
+LIBS="${SSL_LIBS} -llz4"
+CXXFLAGS="-O3 -std=c++11 -Wall -pthread \
+          -DOPENVPN_SHOW_SESSION_TOKEN -DHAVE_LZ4 \
+          -DUSE_ASIO -DASIO_STANDALONE -DASIO_NO_DEPRECATED ${SSL_CFLAGS}"
+
+if [[ "${CC}" == "gcc"* ]]; then
+    CXXFLAGS="${CXXFLAGS} -fwhole-program -flto=4"
+fi
+
+INCLUDEDIRS="-I../../asio/asio/include -I${PREFIX}/include -I../../"
+LDFLAGS="-L${PREFIX}/lib"
+
+if [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+    LDFLAGS="${LDFLAGS} -Wl,--no-as-needed"
+fi
+
+if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+    CXXFLAGS="${CXXFLAGS} -stdlib=libc++ -arch x86_64"
+    LIBS="${LIBS} -framework Security \
+                  -framework CoreFoundation \
+                  -framework SystemConfiguration \
+                  -framework IOKit \
+                  -framework ApplicationServices"
+fi
+
+(
+    cd test/ovpncli
+    ${CXX} ${CXXFLAGS} ${INCLUDEDIRS} ${LDFLAGS} cli.cpp -o cli ${LIBS}
+)
+
+(
+    cd test/ssl
+    ${CXX} ${CXXFLAGS} ${INCLUDEDIRS} ${LDFLAGS} proto.cpp -o proto ${LIBS}
+    ./proto
+)

--- a/.travis/build-deps.sh
+++ b/.travis/build-deps.sh
@@ -1,0 +1,133 @@
+#!/bin/sh
+set -eux
+
+# Set defaults
+PREFIX="${PREFIX:-${HOME}/opt}"
+
+download_asio () {
+    if [ ! -d "download-cache/asio" ]; then
+        git clone https://github.com/chriskohlhoff/asio.git \
+            download-cache/asio
+    else
+        (
+            cd download-cache/asio
+            if [ "$(git log -1 --format=%H)" != "${ASIO_VERSION}" ]; then
+                git checkout master
+                git pull
+                git checkout ${ASIO_VERSION}
+            fi
+        )
+    fi
+}
+
+build_asio () {
+    (
+        if [ ! -L asio ]; then
+            rm -Rf asio
+            ln -s download-cache/asio asio
+        fi
+    )
+}
+
+download_lz4 () {
+    if [ ! -f "download-cache/lz4-${LZ4_VERSION}.tar.gz" ]; then
+        wget "https://github.com/lz4/lz4/archive/v${LZ4_VERSION}.tar.gz" \
+            -O download-cache/lz4-${LZ4_VERSION}.tar.gz
+    fi
+}
+
+build_lz4 () {
+    if [ "$(cat ${PREFIX}/.lz4-version)" != "${LZ4_VERSION}" ]; then
+        tar zxf download-cache/lz4-${LZ4_VERSION}.tar.gz
+        (
+            cd "lz4-${LZ4_VERSION}"
+            make default CC=$CC CXX=$CXX
+            make install PREFIX="${PREFIX}"
+        )
+        echo "${LZ4_VERSION}" > "${PREFIX}/.lz4-version"
+    fi
+}
+
+download_mbedtls () {
+    if [ ! -f "download-cache/mbedtls-${MBEDTLS_VERSION}-apache.tgz" ]; then
+        wget -P download-cache/ \
+            "https://tls.mbed.org/download/mbedtls-${MBEDTLS_VERSION}-apache.tgz"
+    fi
+}
+
+build_mbedtls () {
+    if [ "$(cat ${PREFIX}/.mbedtls-version)" != "${MBEDTLS_VERSION}" ]; then
+        tar zxf download-cache/mbedtls-${MBEDTLS_VERSION}-apache.tgz
+        (
+            cd "mbedtls-${MBEDTLS_VERSION}"
+            make CC=$CC CXX=$CXX
+            make install DESTDIR="${PREFIX}"
+        )
+        echo "${MBEDTLS_VERSION}" > "${PREFIX}/.mbedtls-version"
+    fi
+}
+
+download_openssl () {
+    if [ ! -f "download-cache/openssl-${OPENSSL_VERSION}.tar.gz" ]; then
+        wget -P download-cache/ \
+            "https://www.openssl.org/source/openssl-${OPENSSL_VERSION}.tar.gz"
+    fi
+}
+
+build_openssl_linux () {
+    (
+        cd "openssl-${OPENSSL_VERSION}/"
+        ./config shared --prefix="${PREFIX}" --openssldir="${PREFIX}" -DPURIFY
+        make all install_sw
+    )
+}
+
+build_openssl_osx () {
+    (
+        cd "openssl-${OPENSSL_VERSION}/"
+        ./Configure darwin64-x86_64-cc shared \
+            --prefix="${PREFIX}" --openssldir="${PREFIX}" -DPURIFY
+        make depend all install_sw
+    )
+}
+
+build_openssl () {
+    if [ "$(cat ${PREFIX}/.openssl-version)" != "${OPENSSL_VERSION}" ]; then
+        tar zxf "download-cache/openssl-${OPENSSL_VERSION}.tar.gz"
+        if [ "${TRAVIS_OS_NAME}" = "osx" ]; then
+            build_openssl_osx
+        elif [ "${TRAVIS_OS_NAME}" = "linux" ]; then
+            build_openssl_linux
+        fi
+        echo "${OPENSSL_VERSION}" > "${PREFIX}/.openssl-version"
+    fi
+}
+
+# Enable ccache
+if [ "${TRAVIS_OS_NAME}" != "osx" ] && [ -z ${CHOST+x} ]; then
+    # ccache not available on osx, see:
+    # https://github.com/travis-ci/travis-ci/issues/5567
+    # also ccache not enabled for cross builds
+    mkdir -p "${HOME}/bin"
+    ln -s "$(which ccache)" "${HOME}/bin/${CXX}"
+    ln -s "$(which ccache)" "${HOME}/bin/${CC}"
+    PATH="${HOME}/bin:${PATH}"
+fi
+
+# Download and build crypto lib
+if [ "${SSLLIB}" = "openssl" ]; then
+    download_openssl
+    build_openssl
+elif [ "${SSLLIB}" = "mbedtls" ]; then
+    download_mbedtls
+    build_mbedtls
+else
+    echo "Invalid crypto lib: ${SSLLIB}"
+    exit 1
+fi
+
+download_asio
+build_asio
+
+download_lz4
+build_lz4


### PR DESCRIPTION
Add a .travis.yml file with related scripts in order to
have a special branch built by travis-ci after each push.

At the moment travis-ci has been configured to build for
linux and macos using gcc-5 and clang-5, with both mbedtls
and openssl.

Signed-off-by: Antonio Quartulli <antonio@openvpn.net>