### PR TITLE
travis-ci: make testing binary deterministic

### DIFF
--- a/.travis/build-check.sh
+++ b/.travis/build-check.sh
@@ -56,7 +56,7 @@ fi
 
 (
     cd test/ssl
-    ${CXX} ${CXXFLAGS} ${INCLUDEDIRS} ${LDFLAGS} proto.cpp -o proto ${LIBS}
+    ${CXX} ${CXXFLAGS} -DNOERR ${INCLUDEDIRS} ${LDFLAGS} proto.cpp -o proto ${LIBS}
     ./proto
 )
 


### PR DESCRIPTION
Travis-ci is used only for static analysis, therefore
when building the testing protocol we should avoid
non-deterministic behaviour which could lead to failures.

Tell the testing binary to work with lossless links.

Signed-off-by: Antonio Quartulli <antonio@openvpn.net>