### PR TITLE
Allow GIT version to be reported as part of platform (version) string

### DIFF
--- a/openvpn/common/platform_string.hpp
+++ b/openvpn/common/platform_string.hpp
@@ -37,6 +37,9 @@ namespace openvpn {
     if (!app_version.empty())
       os << app_version << '/';
     os << OPENVPN_VERSION;
+#if defined(GIT_VERSION_STRING)
+    os << "(" <<  GIT_VERSION_STRING << ")";
+#endif
     os << ' ' << platform_name();
 #   if defined(__amd64__) || defined(__x86_64__) || defined(_M_X64) || defined(_M_AMD64)
       os << " x86_64";


### PR DESCRIPTION
A bit of background:

In my own Android App that now includes OpenVPN 3 as alternative I would like to announce the Git revision so it is part of the log as it makes my life a bit easier. 

I use a Android gradle+cmake as build system instead of the standalone (see also https://github.com/schwabe/ics-openvpn/blob/master/main/src/main/cpp/CMakeLists.txt) and allows me to set the GIT_VERSION_STRING as define. Using the gradle+cmake makes debugging the OpenVPN3 code debugging just magically work from Android Studio :)