### PR TITLE
Refuse external pki with non RSA keys

### DIFF
--- a/openvpn/mbedtls/ssl/sslctx.hpp
+++ b/openvpn/mbedtls/ssl/sslctx.hpp
@@ -782,8 +782,13 @@ namespace openvpn {
 		  // set our own certificate, supporting chain (i.e. extra-certs), and external private key
 		  if (c.crt_chain)
 		    {
-		      epki_ctx.epki_enable(ctx, epki_decrypt, epki_sign, epki_key_len);
-		      mbedtls_ssl_conf_own_cert(sslconf, c.crt_chain->get(), epki_ctx.get());
+              if (mbedtls_pk_get_type(&c.crt_chain.get()->get()->pk) == MBEDTLS_PK_RSA) {
+                epki_ctx.epki_enable(ctx, epki_decrypt, epki_sign, epki_key_len);
+                mbedtls_ssl_conf_own_cert(sslconf, c.crt_chain->get(), epki_ctx.get());
+              } else {
+                throw MbedTLSException("cert has unsupported type for external pki support");
+              }
+
 		    }
 		  else
 		    throw MbedTLSException("cert is undefined");


### PR DESCRIPTION
Without this patch you get still specify a client EC certificate and
connect to a RSA server. The connection will be established until the
external pki sign will fail in "interesting" ways.

Signed-off-by: Arne Schwabe <arne@rfc2549.org>

I suspect that this failure scenario is also the reason why the ecdsa ciphersuites are disabled in general but that is actually not necessary.  Connecting to a server with EC certificate works fine with extpki as long as the client uses an RSA certificate.