### PR TITLE
Fixing the instructions in README for OSX builds

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -117,7 +117,7 @@ not required for Mac builds.
 
 Build the dependencies::
 
-    $ OSX_ONLY=1 $O3/core/scripts/mac/build-all
+    $ OSX_ONLY=1 DL=~/src/mac $O3/core/scripts/mac/build-all
 
 Now build the OpenVPN 3 client executable::
 
@@ -125,7 +125,7 @@ Now build the OpenVPN 3 client executable::
     $ . vars/vars-osx64
     $ . vars/setpath
     $ cd test/ovpncli
-    $ MTLS=1 LZ4=1 build cli
+    $ ./go
 
 This will build the OpenVPN 3 client library with a small client
 wrapper (``cli``).  It will also statically link in all external

--- a/deps/asio/build-asio
+++ b/deps/asio/build-asio
@@ -28,6 +28,6 @@ CSUM=${ASIO_CSUM}
 download
 
 cd $DEP_DIR
-rm -rf asio*
+#rm -rf asio*
 tar xf $DL/$ASIO_VERSION.tar.gz
 cp -a $ASIO_VERSION asio


### PR DESCRIPTION
`deps/asio/build-asio` was deleting the file and directory in the `$DL` directory, so it was failing on download itself because it would delete the file and fail before doing anything else
```
tar: Error opening archive: Failed to open '/Users/pgautam/src/mac/asio-862aed305dcf91387535519c9549c17630339a12.tar.gz'
```
additionally, the `./go` script in core did the right thing for mac too.