### PR TITLE
Replace local ip address with gateway address when setuping tun on macOS

### DIFF
--- a/openvpn/tun/mac/client/tunsetup.hpp
+++ b/openvpn/tun/mac/client/tunsetup.hpp
@@ -317,7 +317,7 @@ namespace openvpn {
 	      cmd->argv.push_back("/sbin/ifconfig");
 	      cmd->argv.push_back(iface_name);
 	      cmd->argv.push_back(local4->address);
-	      cmd->argv.push_back(local4->address);
+	      cmd->argv.push_back(local4->gateway);
 	      cmd->argv.push_back("netmask");
 	      cmd->argv.push_back(netmask.to_string());
 	      cmd->argv.push_back("mtu");


### PR DESCRIPTION
According to /sbin/ifconfig manual:
> ifconfig [-L] [-m] [-r] interface [create] [address_family] [address [dest_address]] [parameters]
> ...
> dest_address
>     Specify the address of the correspondent on the other end of a point to point link.

Tunel setup passes local4->address as dest_address to ifconfig. Fix that by replacing local4->address with loca4->gateway