### PR TITLE
ip/ping6: Use _WIN32, not _MSC_VER (to fix MinGW).

### DIFF
--- a/openvpn/ip/ping6.hpp
+++ b/openvpn/ip/ping6.hpp
@@ -38,7 +38,7 @@ namespace openvpn {
 
     inline static const std::uint16_t* get_addr16(const struct in6_addr *addr)
     {
-#if defined(_MSC_VER)
+#if defined(_WIN32)
       return addr->u.Word;
 #elif defined(__APPLE__)
       return addr->__u6_addr.__u6_addr16;


### PR DESCRIPTION
_MSC_VER represents a specific compiler, not a platform, so use _WIN32 to check for what fields to expect on in6_addr to allow compiling with MinGW.

```
openvpn3/openvpn/ip/ping6.hpp:46:20: error: no member named 's6_addr16' in 'in6_addr'
      return addr->s6_addr16;
             ~~~~  ^
```