### PR TITLE
tun/win/tunutil: Don't auto& a temporary iterator.

### DIFF
--- a/openvpn/tun/win/tunutil.hpp
+++ b/openvpn/tun/win/tunutil.hpp
@@ -210,7 +210,7 @@ namespace openvpn {
 	  // first get the TAP guids
 	  {
 	    std::vector<TapGuidLuid> guids = tap_guids(wintun);
-	    for (auto& i = guids.begin(); i != guids.end(); i++)
+	    for (auto i = guids.begin(); i != guids.end(); i++)
 	      {
 		TapNameGuidPair pair;
 		pair.guid = i->first;


### PR DESCRIPTION
The current Tun code fails on Windows due to trying to take a reference to a temporary:

        openvpn3/openvpn/tun/win/tunutil.hpp:213:17: error: non-const lvalue reference to type '__wrap_iter<...>' cannot bind to a temporary of type '__wrap_iter<...>'
                    for (auto& i = guids.begin(); i != guids.end(); i++)
                               ^   ~~~~~~~~~~~~~

The type of guids.begin() is a value iterator, and so needs to be declared with "auto".
