### PR TITLE
mac/tuncli: Don't take address of temporary error.

### DIFF
--- a/openvpn/tun/tunio.hpp
+++ b/openvpn/tun/tunio.hpp
@@ -116,7 +116,8 @@ namespace openvpn {
 	  catch (openvpn_io::system_error& e)
 	    {
 	      OPENVPN_LOG_TUN_ERROR("TUN write exception: " << e.what());
-	      tun_error(Error::TUN_WRITE_ERROR, &e.code());
+	      const openvpn_io::error_code code(e.code());
+	      tun_error(Error::TUN_WRITE_ERROR, &code);
 	      return false;
 	    }
 	}
@@ -149,7 +150,8 @@ namespace openvpn {
 	  catch (openvpn_io::system_error& e)
 	    {
 	      OPENVPN_LOG_TUN_ERROR("TUN write exception: " << e.what());
-	      tun_error(Error::TUN_WRITE_ERROR, &e.code());
+	      const openvpn_io::error_code code(e.code());
+	      tun_error(Error::TUN_WRITE_ERROR, &code);
 	      return false;
 	    }
 	}


### PR DESCRIPTION
The function code() on a system_error returns a temporary value of type error_code; using & on such a value is incorrect.

    In file included from openvpn3/test/ovpncli/cli.cpp:58:
    In file included from openvpn3/client/ovpncli.cpp:97:
    In file included from openvpn3/openvpn/client/cliconnect.hpp:60:
    In file included from openvpn3/openvpn/client/cliopt.hpp:85:
    In file included from openvpn3/openvpn/tun/mac/client/tuncli.hpp:38:
    openvpn3/openvpn/tun/tunio.hpp:119:42: error: taking the address of a temporary object of type 'boost::system::error_code' [-Waddress-of-temporary]
                  tun_error(Error::TUN_WRITE_ERROR, &e.code());
                                                    ^~~~~~~~~
    openvpn3/openvpn/tun/tunio.hpp:152:42: error: taking the address of a temporary object of type 'boost::system::error_code' [-Waddress-of-temporary]
                  tun_error(Error::TUN_WRITE_ERROR, &e.code());
                                                    ^~~~~~~~~
    openvpn3/openvpn/tun/tunio.hpp:119:42: error: taking the address of a temporary object of type 'boost::system::error_code' [-Waddress-of-temporary]
                  tun_error(Error::TUN_WRITE_ERROR, &e.code());
                                                    ^~~~~~~~~
    openvpn3/openvpn/tun/mac/client/tuncli.hpp:330:17: note: in instantiation of member function 'openvpn::TunIO<openvpn::TunMac::Client *, openvpn::TunMac::PacketFrom, openvpn::TunWrapAsioStream<openvpn::TunPersistTemplate<openvpn::ScopedAsioStream<boost::asio::posix::basic_stream_descriptor<boost::asio::executor> > > > >::write' requested here
              return impl->write(buf);
                           ^

Signed-off-by: Jay Freeman (saurik) <saurik@saurik.com>