### PR TITLE
Add an interface for Pluggable Transports

### DIFF
--- a/client/ovpncli.cpp
+++ b/client/ovpncli.cpp
@@ -466,6 +466,7 @@ namespace openvpn {
 	bool dco = false;
 	bool echo = false;
 	bool info = false;
+	bool pt = false;
 
 	// Ensure that init is called
 	InitProcess::Init init;
@@ -710,6 +711,7 @@ namespace openvpn {
 	state->alt_proxy = config.altProxy;
 	state->dco = config.dco;
 	state->echo = config.echo;
+	state->pt = config.usePluggableTransports;
 	state->info = config.info;
 	state->clock_tick_ms = config.clockTickMS;
 	if (!config.gremlinConfig.empty())
@@ -1001,6 +1003,11 @@ namespace openvpn {
 #endif
 #if defined(OPENVPN_EXTERNAL_TUN_FACTORY)
       cc.extern_tun_factory = this;
+#endif
+#if defined(OPENVPN_PLUGGABLE_TRANSPORTS)
+      if (state->pt) {
+        cc.pluggable_transports_factory = this;
+      }
 #endif
 #if defined(OPENVPN_EXTERNAL_TRANSPORT_FACTORY)
       cc.extern_transport_factory = this;

--- a/client/ovpncli.hpp
+++ b/client/ovpncli.hpp
@@ -33,6 +33,8 @@
 #include <openvpn/pki/epkibase.hpp>
 #include <openvpn/transport/client/extern/fw.hpp>
 
+#include <openvpn/transport/client/pluggable/fw.hpp>
+
 namespace openvpn {
   class OptionList;
   class ProfileMerge;
@@ -318,6 +320,9 @@ namespace openvpn {
       // Gremlin configuration (requires that the core is built with OPENVPN_GREMLIN)
       std::string gremlinConfig;
 
+      // Use pluggable transports factory (requires that the core is build with OPENVPN_PLUGGABLE_TRANSPORTS)
+      bool usePluggableTransports = false;
+
       // Use wintun instead of tap-windows6 on Windows
       bool wintun = false;
     };
@@ -459,9 +464,10 @@ namespace openvpn {
 
     // Top-level OpenVPN client class.
     class OpenVPNClient : public TunBuilderBase,            // expose tun builder virtual methods
-			  public LogReceiver,               // log message notification
-			  public ExternalTun::Factory,      // low-level tun override
-			  public ExternalTransport::Factory,// low-level transport override
+			  public LogReceiver,                 // log message notification
+			  public ExternalTun::Factory,        // low-level tun override
+			  public PluggableTransports::Factory,// pluggable transport override. 
+			  public ExternalTransport::Factory,  // low-level transport override
 			  private ExternalPKIBase
     {
     public:

--- a/javacli/ovpncli.i
+++ b/javacli/ovpncli.i
@@ -15,6 +15,7 @@
 // ignore these ClientAPI::OpenVPNClient bases
 %ignore openvpn::ClientAPI::LogReceiver;
 %ignore openvpn::ExternalTun::Factory;
+%ignore openvpn::PluggableTransports::Factory;
 %ignore openvpn::ExternalTransport::Factory;
 
 // modify exported C++ class names to incorporate their enclosing namespace
@@ -51,5 +52,6 @@ namespace std {
 %include "openvpn/pki/epkibase.hpp"
 %include "openvpn/tun/builder/base.hpp"
 %import  "openvpn/tun/extern/fw.hpp"     // ignored
+%import  "openvpn/transport/client/pluggable/fw.hpp"  // ignored
 %import  "openvpn/transport/client/extern/fw.hpp"     // ignored
 %include "ovpncli.hpp"

--- a/openvpn/error/error.hpp
+++ b/openvpn/error/error.hpp
@@ -59,6 +59,9 @@ namespace openvpn {
       TCP_SIZE_ERROR,      // bad embedded uint16_t TCP packet size
       TCP_CONNECT_ERROR,   // client error on TCP connect
       UDP_CONNECT_ERROR,   // client error on UDP connect
+      PT_CONNECT_ERROR,    // client error on Pluggable Transports connect
+      PT_OVERFLOW,         // Pluggable Transports output queue overflow
+      PT_SIZE_ERROR,       // Pluggable Transports bad packet size
       SSL_ERROR,           // errors resulting from read/write on SSL object
       SSL_PARTIAL_WRITE,   // SSL object did not process all written cleartext
       SSL_CA_MD_TOO_WEAK,  // CA message digest is too weak
@@ -141,6 +144,9 @@ namespace openvpn {
 	"TCP_SIZE_ERROR",
 	"TCP_CONNECT_ERROR",
 	"UDP_CONNECT_ERROR",
+	"PT_CONNECT_ERROR",
+	"PT_OVERFLOW",
+	"PT_SIZE_ERROR",
 	"SSL_ERROR",
 	"SSL_PARTIAL_WRITE",
 	"SSL_CA_MD_TOO_WEAK",

--- a/openvpn/transport/client/pluggable/fw.hpp
+++ b/openvpn/transport/client/pluggable/fw.hpp
@@ -1,0 +1,43 @@
+//    OpenVPN -- An application to securely tunnel IP networks
+//               over a single port, with support for SSL/TLS-based
+//               session authentication and key exchange,
+//               packet encryption, packet authentication, and
+//               packet compression.
+//
+//    Copyright (C) 2012-2020 OpenVPN Inc.
+//
+//    This program is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Affero General Public License Version 3
+//    as published by the Free Software Foundation.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program in the COPYING file.
+//    If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef OPENVPN_TRANSPORT_CLIENT_PLUGGABLE_FW_H
+#define OPENVPN_TRANSPORT_CLIENT_PLUGGABLE_FW_H
+
+#ifdef OPENVPN_PLUGGABLE_TRANSPORTS
+#include <openvpn/transport/client/transbase.hpp>
+#include <openvpn/transport/client/pluggable/pt.hpp>
+#endif
+
+namespace openvpn {
+  namespace PluggableTransports {
+#ifdef OPENVPN_PLUGGABLE_TRANSPORTS
+    struct Factory
+    {
+      virtual openvpn::PluggableTransports::Transport::Ptr new_transport_factory() = 0;
+      virtual ~Factory() {}
+    };
+#else
+    struct Factory {};
+#endif
+  }
+}
+#endif

--- a/openvpn/transport/client/pluggable/pt.hpp
+++ b/openvpn/transport/client/pluggable/pt.hpp
@@ -1,0 +1,54 @@
+//    OpenVPN -- An application to securely tunnel IP networks
+//               over a single port, with support for SSL/TLS-based
+//               session authentication and key exchange,
+//               packet encryption, packet authentication, and
+//               packet compression.
+//
+//    Copyright (C) 2012-2020 OpenVPN Inc.
+//
+//    This program is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Affero General Public License Version 3
+//    as published by the Free Software Foundation.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program in the COPYING file.
+//    If not, see <http://www.gnu.org/licenses/>.
+
+#ifndef OPENVPN_TRANSPORT_CLIENT_PT_H
+#define OPENVPN_TRANSPORT_CLIENT_PT_H
+
+#include <openvpn/io/io.hpp>
+#include <openvpn/common/rc.hpp>
+
+#ifdef OPENVPN_PLUGGABLE_TRANSPORTS
+
+namespace openvpn {
+  namespace PluggableTransports {
+    struct Connection : public RC<thread_unsafe_refcount>
+    {
+      typedef RCPtr<Connection> Ptr;
+
+      virtual size_t send(const openvpn_io::const_buffer& buffer) = 0;
+      virtual size_t receive(const openvpn_io::mutable_buffer& buffer) = 0;
+      virtual void close() = 0;
+      virtual int native_handle() = 0;
+    };
+
+    struct Transport: public RC<thread_unsafe_refcount>
+    {
+      typedef RCPtr<Transport> Ptr;
+
+    public:
+      virtual PluggableTransports::Connection::Ptr dial(openvpn_io::ip::tcp::endpoint address) = 0;
+    };
+  }
+}
+
+#endif // OPENVPN_PLUGGABLE_TRANSPORTS
+
+#endif

--- a/openvpn/transport/client/pluggable/ptcli.hpp
+++ b/openvpn/transport/client/pluggable/ptcli.hpp
@@ -1,0 +1,399 @@
+//    OpenVPN -- An application to securely tunnel IP networks
+//               over a single port, with support for SSL/TLS-based
+//               session authentication and key exchange,
+//               packet encryption, packet authentication, and
+//               packet compression.
+//
+//    Copyright (C) 2012-2020 OpenVPN Inc.
+//
+//    This program is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Affero General Public License Version 3
+//    as published by the Free Software Foundation.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program in the COPYING file.
+//    If not, see <http://www.gnu.org/licenses/>.
+
+// TCP transport object specialized for client.
+
+#ifndef OPENVPN_TRANSPORT_CLIENT_TCPCLI_H
+#define OPENVPN_TRANSPORT_CLIENT_TCPCLI_H
+
+#include <sstream>
+
+#include <openvpn/io/io.hpp>
+
+#include <openvpn/transport/tcplink.hpp>
+#ifdef OPENVPN_TLS_LINK
+#include <openvpn/transport/tlslink.hpp>
+#endif
+#include <openvpn/transport/client/transbase.hpp>
+#include <openvpn/transport/socket_protect.hpp>
+#include <openvpn/client/remotelist.hpp>
+
+namespace openvpn {
+  namespace TCPTransport {
+
+    class ClientConfig : public TransportClientFactory
+    {
+    public:
+      typedef RCPtr<ClientConfig> Ptr;
+
+      RemoteList::Ptr remote_list;
+      size_t free_list_max_size;
+      Frame::Ptr frame;
+      SessionStats::Ptr stats;
+
+      SocketProtect* socket_protect;
+
+#ifdef OPENVPN_TLS_LINK
+      bool use_tls = false;
+      std::string tls_ca;
+#endif
+
+#ifdef OPENVPN_GREMLIN
+      Gremlin::Config::Ptr gremlin_config;
+#endif
+
+      static Ptr new_obj()
+      {
+	return new ClientConfig;
+      }
+
+      virtual TransportClient::Ptr new_transport_client_obj(openvpn_io::io_context& io_context,
+							    TransportClientParent* parent);
+
+    private:
+      ClientConfig()
+	: free_list_max_size(8),
+	  socket_protect(nullptr)
+      {}
+    };
+
+    class Client : public TransportClient, AsyncResolvableTCP
+    {
+      typedef RCPtr<Client> Ptr;
+
+      typedef Link<openvpn_io::ip::tcp, Client*, false> LinkImpl;
+#ifdef OPENVPN_TLS_LINK
+      typedef TLSLink<openvpn_io::ip::tcp, Client*, false> LinkImplTLS;
+#endif
+
+      friend class ClientConfig;         // calls constructor
+      friend LinkImpl::Base;             // calls tcp_read_handler
+
+    public:
+      void transport_start() override
+      {
+	if (!impl)
+	  {
+	    halt = false;
+	    stop_requeueing = false;
+	    if (config->remote_list->endpoint_available(&server_host,
+							&server_port,
+							&server_protocol))
+	      {
+		start_connect_();
+	      }
+	    else
+	      {
+		parent->transport_pre_resolve();
+
+		async_resolve_name(server_host, server_port);
+	      }
+	  }
+      }
+
+      bool transport_send_const(const Buffer& buf) override
+      {
+	return send_const(buf);
+      }
+
+      bool transport_send(BufferAllocated& buf) override
+      {
+	return send(buf);
+      }
+
+      bool transport_send_queue_empty() override
+      {
+	if (impl)
+	  return impl->send_queue_empty();
+	else
+	  return false;
+      }
+
+      bool transport_has_send_queue() override
+      {
+	return true;
+      }
+
+      unsigned int transport_send_queue_size() override
+      {
+	if (impl)
+	  return impl->send_queue_size();
+	else
+	  return 0;
+      }
+
+      void reset_align_adjust(const size_t align_adjust) override
+      {
+	if (impl)
+	  impl->reset_align_adjust(align_adjust);
+      }
+
+      void server_endpoint_info(std::string& host, std::string& port, std::string& proto, std::string& ip_addr) const override
+      {
+	host = server_host;
+	port = server_port;
+	const IP::Addr addr = server_endpoint_addr();
+	proto = server_protocol.str();
+	ip_addr = addr.to_string();
+      }
+
+      IP::Addr server_endpoint_addr() const override
+      {
+	return IP::Addr::from_asio(server_endpoint.address());
+      }
+
+      Protocol transport_protocol() const override
+      {
+	return server_protocol;
+      }
+
+      void stop() override { stop_(); }
+      ~Client() override { stop_(); }
+
+    private:
+      Client(openvpn_io::io_context& io_context_arg,
+	     ClientConfig* config_arg,
+	     TransportClientParent* parent_arg)
+	:  AsyncResolvableTCP(io_context_arg),
+	   io_context(io_context_arg),
+	   socket(io_context_arg),
+	   config(config_arg),
+	   parent(parent_arg),
+	   resolver(io_context_arg),
+	   halt(false),
+	   stop_requeueing(false)
+      {
+      }
+
+      void transport_reparent(TransportClientParent* parent_arg) override
+      {
+	parent = parent_arg;
+      }
+
+      void transport_stop_requeueing() override
+      {
+	stop_requeueing = true;
+      }
+
+      bool send_const(const Buffer& cbuf)
+      {
+	if (impl)
+	  {
+	    BufferAllocated buf(cbuf, 0);
+	    return impl->send(buf);
+	  }
+	else
+	  return false;
+      }
+
+      bool send(BufferAllocated& buf)
+      {
+	if (impl)
+	  return impl->send(buf);
+	else
+	  return false;
+      }
+
+      void tcp_eof_handler() // called by LinkImpl::Base
+      {
+	config->stats->error(Error::NETWORK_EOF_ERROR);
+	tcp_error_handler("NETWORK_EOF_ERROR");
+      }
+
+      bool tcp_read_handler(BufferAllocated& buf) // called by LinkImpl::Base
+      {
+	parent->transport_recv(buf);
+	return !stop_requeueing;
+      }
+
+      void tcp_write_queue_needs_send() // called by LinkImpl::Base
+      {
+	parent->transport_needs_send();
+      }
+
+      void tcp_error_handler(const char *error) // called by LinkImpl::Base
+      {
+	std::ostringstream os;
+	os << "Transport error on '" << server_host << ": " << error;
+	stop();
+	parent->transport_error(Error::TRANSPORT_ERROR, os.str());
+      }
+
+      void stop_()
+      {
+	if (!halt)
+	  {
+	    halt = true;
+	    if (impl)
+	      impl->stop();
+
+	    socket.close();
+	    resolver.cancel();
+	    async_resolve_cancel();
+	  }
+      }
+
+      // do DNS resolve
+      void resolve_callback(const openvpn_io::error_code& error,
+			    openvpn_io::ip::tcp::resolver::results_type results) override
+      {
+	if (!halt)
+	  {
+	    if (!error)
+	      {
+		// save resolved endpoint list in remote_list
+		config->remote_list->set_endpoint_range(results);
+		start_connect_();
+	      }
+	    else
+	      {
+		std::ostringstream os;
+		os << "DNS resolve error on '" << server_host << "' for " << server_protocol.str() << " session: " << error.message();
+		config->stats->error(Error::RESOLVE_ERROR);
+		stop();
+		parent->transport_error(Error::UNDEF, os.str());
+	      }
+	  }
+      }
+
+      // do TCP connect
+      void start_connect_()
+      {
+	config->remote_list->get_endpoint(server_endpoint);
+	OPENVPN_LOG("Contacting " << server_endpoint << " via "
+		    << server_protocol.str());
+	parent->transport_wait();
+	socket.open(server_endpoint.protocol());
+
+	if (config->socket_protect)
+	  {
+	    if (!config->socket_protect->socket_protect(socket.native_handle(), server_endpoint_addr()))
+	      {
+		config->stats->error(Error::SOCKET_PROTECT_ERROR);
+		stop();
+		parent->transport_error(Error::UNDEF, "socket_protect error (" + std::string(server_protocol.str()) + ")");
+		return;
+	      }
+	  }
+
+	socket.set_option(openvpn_io::ip::tcp::no_delay(true));
+	socket.async_connect(server_endpoint, [self=Ptr(this)](const openvpn_io::error_code& error)
+                                              {
+                                                OPENVPN_ASYNC_HANDLER;
+                                                self->start_impl_(error);
+                                              });
+      }
+
+      // start I/O on TCP socket
+      void start_impl_(const openvpn_io::error_code& error)
+      {
+	if (!halt)
+	  {
+	    if (!error)
+	      {
+#ifdef OPENVPN_TLS_LINK
+		if (config->use_tls)
+		{
+		  int flags = SSLConst::LOG_VERIFY_STATUS|SSLConst::ENABLE_CLIENT_SNI;
+		  SSLLib::SSLAPI::Config::Ptr ssl_conf;
+		  ssl_conf.reset(new SSLLib::SSLAPI::Config());
+		  ssl_conf->set_mode(Mode(Mode::CLIENT));
+		  ssl_conf->set_local_cert_enabled(false);
+		  ssl_conf->set_frame(config->frame);
+		  ssl_conf->set_rng(new SSLLib::RandomAPI(false));
+
+		  if (!config->tls_ca.empty())
+		  {
+		    ssl_conf->load_ca(config->tls_ca, true);
+		  }
+		  else
+		  {
+		    flags |= SSLConst::NO_VERIFY_PEER;
+		  }
+
+		  ssl_conf->set_flags(flags);
+		  ssl_factory = ssl_conf->new_factory();
+
+		  impl.reset(new LinkImplTLS(this,
+					     io_context,
+					     socket,
+					     0,
+					     config->free_list_max_size,
+					     config->frame,
+					     config->stats,
+					     ssl_factory));
+		}
+		else
+#endif
+		  impl.reset(new LinkImpl(this,
+					  socket,
+					  0, // send_queue_max_size is unlimited because we regulate size in cliproto.hpp
+					  config->free_list_max_size,
+					  (*config->frame)[Frame::READ_LINK_TCP],
+					  config->stats));
+
+#ifdef OPENVPN_GREMLIN
+		impl->gremlin_config(config->gremlin_config);
+#endif
+		impl->start();
+		if (!parent->transport_is_openvpn_protocol())
+		  impl->set_raw_mode(true);
+		parent->transport_connecting();
+	      }
+	    else
+	      {
+		std::ostringstream os;
+		os << server_protocol.str() << " connect error on '" << server_host << ':' << server_port << "' (" << server_endpoint << "): " << error.message();
+		config->stats->error(Error::TCP_CONNECT_ERROR);
+		stop();
+		parent->transport_error(Error::UNDEF, os.str());
+	      }
+	  }
+      }
+
+      std::string server_host;
+      std::string server_port;
+      Protocol server_protocol;
+
+      openvpn_io::io_context& io_context;
+      openvpn_io::ip::tcp::socket socket;
+      ClientConfig::Ptr config;
+      TransportClientParent* parent;
+      LinkBase::Ptr impl;
+      openvpn_io::ip::tcp::resolver resolver;
+      LinkImpl::Base::protocol::endpoint server_endpoint;
+      bool halt;
+      bool stop_requeueing;
+
+#ifdef OPENVPN_TLS_LINK
+      SSLFactoryAPI::Ptr ssl_factory;
+#endif
+    };
+
+    inline TransportClient::Ptr ClientConfig::new_transport_client_obj(openvpn_io::io_context& io_context,
+								       TransportClientParent* parent)
+    {
+      return TransportClient::Ptr(new Client(io_context, this, parent));
+    }
+  }
+} // namespace openvpn
+
+#endif

--- a/openvpn/transport/client/pluggable/ptcli.hpp
+++ b/openvpn/transport/client/pluggable/ptcli.hpp
@@ -235,7 +235,7 @@ namespace openvpn {
 	    if (impl)
 	      impl->stop();
 
-	    if (connection) 
+	    if (connection)
 	      connection->close();
 
 	    resolver.cancel();
@@ -315,7 +315,7 @@ namespace openvpn {
       }
 
       bool socket_protect() {
-	if (config->socket_protect) 
+	if (config->socket_protect)
 	  {
 	    int fd = connection->native_handle();
 	    // short circuit prevents socket_protect from being evaluated when fd < 0
@@ -327,12 +327,12 @@ namespace openvpn {
 	return true;
       }
 
-      // start I/O 
+      // start I/O
       void start_impl_(const Error::Type error)
       {
 	if (!halt)
 	  {
-	    if (!error) 
+	    if (!error)
 	      {
 		impl.reset(new Link(io_context,
 				    this,

--- a/openvpn/transport/client/pluggable/ptcli.hpp
+++ b/openvpn/transport/client/pluggable/ptcli.hpp
@@ -79,9 +79,9 @@ namespace openvpn {
     {
       typedef RCPtr<Client> Ptr;
 
-      typedef LinkImpl<openvpn_io::ip::tcp, Client*, false> Link;
+      typedef LinkImpl<openvpn_io::ip::tcp, Client*> Link;
 #ifdef OPENVPN_TLS_LINK
-      typedef TLSLink<openvpn_io::ip::tcp, Client*, false> LinkImplTLS;
+      typedef TLSLink<openvpn_io::ip::tcp, Client*> LinkImplTLS;
 #endif
 
       friend class ClientConfig;         // calls constructor
@@ -353,8 +353,6 @@ namespace openvpn {
 		impl->gremlin_config(config->gremlin_config);
 #endif
 		impl->start();
-		if (!parent->transport_is_openvpn_protocol())
-		  impl->set_raw_mode(true);
 		parent->transport_connecting();
 	      }
 	    else

--- a/openvpn/transport/client/pluggable/ptcli.hpp
+++ b/openvpn/transport/client/pluggable/ptcli.hpp
@@ -29,9 +29,6 @@
 #include <openvpn/io/io.hpp>
 
 #include <openvpn/transport/ptlink.hpp>
-#ifdef OPENVPN_TLS_LINK
-#include <openvpn/transport/tlslink.hpp>
-#endif
 #include <openvpn/transport/client/transbase.hpp>
 #include <openvpn/transport/socket_protect.hpp>
 #include <openvpn/client/remotelist.hpp>
@@ -50,11 +47,6 @@ namespace openvpn {
       SessionStats::Ptr stats;
 
       SocketProtect* socket_protect;
-
-#ifdef OPENVPN_TLS_LINK
-      bool use_tls = false;
-      std::string tls_ca;
-#endif
 
 #ifdef OPENVPN_GREMLIN
       Gremlin::Config::Ptr gremlin_config;
@@ -79,10 +71,7 @@ namespace openvpn {
     {
       typedef RCPtr<Client> Ptr;
 
-      typedef LinkImpl<openvpn_io::ip::tcp, Client*> Link;
-#ifdef OPENVPN_TLS_LINK
-      typedef TLSLink<openvpn_io::ip::tcp, Client*> LinkImplTLS;
-#endif
+      typedef LinkImpl<Client*> Link;
 
       friend class ClientConfig;         // calls constructor
       friend Link;                       // calls pt_read_handler
@@ -96,7 +85,7 @@ namespace openvpn {
 	    stop_requeueing = false;
 	    if (config->remote_list->endpoint_available(&server_host,
 							&server_port,
-							&server_protocol))
+							nullptr))
 	      {
 		start_connect_();
 	      }
@@ -151,7 +140,7 @@ namespace openvpn {
 	host = server_host;
 	port = server_port;
 	const IP::Addr addr = server_endpoint_addr();
-	proto = server_protocol.str();
+	proto = "PluggableTransports";
 	ip_addr = addr.to_string();
       }
 
@@ -162,7 +151,7 @@ namespace openvpn {
 
       Protocol transport_protocol() const override
       {
-	return server_protocol;
+	return Protocol();
       }
 
       void stop() override { stop_(); }
@@ -288,7 +277,6 @@ namespace openvpn {
 	      {
 		config->stats->error(Error::SOCKET_PROTECT_ERROR);
 		stop();
-		parent->transport_error(Error::UNDEF, "socket_protect error (" + std::string(server_protocol.str()) + ")");
 		return;
 	      }
 	  }
@@ -308,46 +296,12 @@ namespace openvpn {
 	  {
 	    if (!error)
 	      {
-#ifdef OPENVPN_TLS_LINK
-		if (config->use_tls)
-		{
-		  int flags = SSLConst::LOG_VERIFY_STATUS|SSLConst::ENABLE_CLIENT_SNI;
-		  SSLLib::SSLAPI::Config::Ptr ssl_conf;
-		  ssl_conf.reset(new SSLLib::SSLAPI::Config());
-		  ssl_conf->set_mode(Mode(Mode::CLIENT));
-		  ssl_conf->set_local_cert_enabled(false);
-		  ssl_conf->set_frame(config->frame);
-		  ssl_conf->set_rng(new SSLLib::RandomAPI(false));
-
-		  if (!config->tls_ca.empty())
-		  {
-		    ssl_conf->load_ca(config->tls_ca, true);
-		  }
-		  else
-		  {
-		    flags |= SSLConst::NO_VERIFY_PEER;
-		  }
-
-		  ssl_conf->set_flags(flags);
-		  ssl_factory = ssl_conf->new_factory();
-
-		  impl.reset(new LinkImplTLS(this,
-					     io_context,
-					     socket,
-					     0,
-					     config->free_list_max_size,
-					     config->frame,
-					     config->stats,
-					     ssl_factory));
-		}
-		else
-#endif
-		  impl.reset(new Link(this,
-				      socket,
-				      0, // send_queue_max_size is unlimited because we regulate size in cliproto.hpp
-				      config->free_list_max_size,
-				      (*config->frame)[Frame::READ_LINK_TCP],
-				      config->stats));
+		impl.reset(new Link(this,
+				    socket,
+				    0, // send_queue_max_size is unlimited because we regulate size in cliproto.hpp
+				    config->free_list_max_size,
+				    (*config->frame)[Frame::READ_LINK_TCP],
+				    config->stats));
 
 #ifdef OPENVPN_GREMLIN
 		impl->gremlin_config(config->gremlin_config);
@@ -368,7 +322,6 @@ namespace openvpn {
 
       std::string server_host;
       std::string server_port;
-      Protocol server_protocol;
 
       openvpn_io::io_context& io_context;
       openvpn_io::ip::tcp::socket socket;
@@ -379,10 +332,6 @@ namespace openvpn {
       Link::protocol::endpoint server_endpoint;
       bool halt;
       bool stop_requeueing;
-
-#ifdef OPENVPN_TLS_LINK
-      SSLFactoryAPI::Ptr ssl_factory;
-#endif
     };
 
     inline TransportClient::Ptr ClientConfig::new_transport_client_obj(openvpn_io::io_context& io_context,

--- a/openvpn/transport/client/transbase.hpp
+++ b/openvpn/transport/client/transbase.hpp
@@ -27,14 +27,10 @@
 
 #include <string>
 
-#include <openvpn/io/io.hpp>
-
-#include <openvpn/common/exception.hpp>
 #include <openvpn/common/rc.hpp>
 #include <openvpn/buffer/buffer.hpp>
 #include <openvpn/addr/ip.hpp>
 #include <openvpn/error/error.hpp>
-#include <openvpn/crypto/cryptodc.hpp>
 #include <openvpn/transport/protocol.hpp>
 
 namespace openvpn {

--- a/openvpn/transport/ptlink.hpp
+++ b/openvpn/transport/ptlink.hpp
@@ -1,0 +1,457 @@
+//    Copyright (C) 2012-2020 OpenVPN Inc.
+
+// Base class for TCP link objects.
+
+#ifndef OPENVPN_TRANSPORT_COMMONLINK_H
+#define OPENVPN_TRANSPORT_COMMONLINK_H
+
+#include <deque>
+#include <utility> // for std::move
+#include <memory>
+
+#include <openvpn/io/io.hpp>
+
+#include <openvpn/common/size.hpp>
+#include <openvpn/common/rc.hpp>
+#include <openvpn/common/socktypes.hpp>
+#include <openvpn/error/excode.hpp>
+#include <openvpn/frame/frame.hpp>
+#include <openvpn/log/sessionstats.hpp>
+#include <openvpn/transport/tcplinkbase.hpp>
+#include <openvpn/transport/pktstream.hpp>
+#include <openvpn/transport/mutate.hpp>
+
+#ifdef OPENVPN_GREMLIN
+#include <openvpn/transport/gremlin.hpp>
+#endif
+
+#if defined(OPENVPN_DEBUG_TCPLINK) && OPENVPN_DEBUG_TCPLINK >= 1
+#define OPENVPN_LOG_TCPLINK_ERROR(x) OPENVPN_LOG(x)
+#else
+#define OPENVPN_LOG_TCPLINK_ERROR(x)
+#endif
+
+#if defined(OPENVPN_DEBUG_TCPLINK) && OPENVPN_DEBUG_TCPLINK >= 3
+#define OPENVPN_LOG_TCPLINK_VERBOSE(x) OPENVPN_LOG(x)
+#else
+#define OPENVPN_LOG_TCPLINK_VERBOSE(x)
+#endif
+
+namespace openvpn {
+  namespace TCPTransport {
+
+    template <typename Protocol,
+	      typename ReadHandler,
+	      bool RAW_MODE_ONLY>
+    class LinkCommon : public LinkBase
+    {
+      typedef std::deque<BufferPtr> Queue;
+
+    public:
+      typedef RCPtr<LinkCommon<Protocol, ReadHandler, RAW_MODE_ONLY>> Ptr;
+      typedef Protocol protocol;
+
+      // In raw mode, data is sent and received without any special encapsulation.
+      // In non-raw mode, data is packetized by prepending a 16-bit length word
+      // onto each packet.  The OpenVPN protocol runs in non-raw mode, while other
+      // TCP protocols such as HTTP or HTTPS would run in raw mode.
+      // This method is a no-op if RAW_MODE_ONLY is true.
+      void set_raw_mode(const bool mode)
+      {
+	set_raw_mode_read(mode);
+	set_raw_mode_write(mode);
+      }
+
+      void set_raw_mode_read(const bool mode)
+      {
+	if (RAW_MODE_ONLY)
+	  raw_mode_read = true;
+	else
+	  raw_mode_read = mode;
+      }
+
+      void set_raw_mode_write(const bool mode)
+      {
+	if (RAW_MODE_ONLY)
+	  raw_mode_write = true;
+	else
+	  raw_mode_write = mode;
+      }
+
+      void set_mutate(const TransportMutateStream::Ptr& mutate_arg)
+      {
+	mutate = mutate_arg;
+      }
+
+      bool send_queue_empty() const
+      {
+	return send_queue_size() == 0;
+      }
+
+      void inject(const Buffer& src)
+      {
+	const size_t size = src.size();
+	OPENVPN_LOG_TCPLINK_VERBOSE("TCP inject size=" << size);
+	if (size && !RAW_MODE_ONLY)
+	  {
+	    BufferAllocated buf;
+	    frame_context.prepare(buf);
+	    buf.write(src.c_data(), size);
+	    BufferAllocated pkt;
+	    put_pktstream(buf, pkt);
+	  }
+      }
+
+      void start()
+      {
+	if (!halt)
+	  queue_recv(nullptr);
+      }
+
+      void stop()
+      {
+	halt = true;
+#ifdef OPENVPN_GREMLIN
+	if (gremlin)
+	  gremlin->stop();
+#endif
+      }
+
+      void reset_align_adjust(const size_t align_adjust)
+      {
+	frame_context.reset_align_adjust(align_adjust + (is_raw_mode() ? 0 : 2));
+      }
+
+      unsigned int send_queue_size() const
+      {
+	return queue.size()
+#ifdef OPENVPN_GREMLIN
+	  + (gremlin ? gremlin->send_size() : 0)
+#endif
+	  ;
+      }
+
+      bool send(BufferAllocated& b)
+      {
+	if (halt)
+	  return false;
+
+	if (send_queue_max_size && send_queue_size() >= send_queue_max_size)
+	  {
+	    stats->error(Error::TCP_OVERFLOW);
+	    read_handler->tcp_error_handler("TCP_OVERFLOW");
+	    stop();
+	    return false;
+	  }
+
+	BufferPtr buf;
+	if (!free_list.empty())
+	  {
+	    buf = free_list.front();
+	    free_list.pop_front();
+	  }
+	else
+	  buf.reset(new BufferAllocated());
+	buf->swap(b);
+	if (!is_raw_mode_write())
+	  PacketStream::prepend_size(*buf);
+	if (mutate)
+	  mutate->pre_send(*buf);
+#ifdef OPENVPN_GREMLIN
+	if (gremlin)
+	  gremlin_queue_send_buffer(buf);
+	else
+#endif
+	from_app_send_buffer(buf);
+	return true;
+      }
+
+      void queue_recv(PacketFrom *tcpfrom)
+      {
+	OPENVPN_LOG_TCPLINK_VERBOSE("TLSLink::queue_recv");
+	if (!tcpfrom)
+	  tcpfrom = new PacketFrom();
+	frame_context.prepare(tcpfrom->buf);
+
+	socket.async_receive(frame_context.mutable_buffer_clamp(tcpfrom->buf),
+			     [self=Ptr(this), tcpfrom=PacketFrom::SPtr(tcpfrom)](const openvpn_io::error_code& error, const size_t bytes_recvd) mutable
+			     {
+			       OPENVPN_ASYNC_HANDLER;
+			       try
+			       {
+			         self->handle_recv(std::move(tcpfrom), error, bytes_recvd);
+			       }
+			       catch (const std::exception& e)
+			       {
+			         Error::Type err = Error::TCP_SIZE_ERROR;
+				 const char *msg = "TCP_SIZE_ERROR";
+			         // if exception is an ExceptionCode, translate the code
+				 // to return status string
+				 {
+				   const ExceptionCode *ec = dynamic_cast<const ExceptionCode *>(&e);
+				   if (ec && ec->code_defined())
+				   {
+				     err = ec->code();
+				     msg = ec->what();
+				   }
+				 }
+
+			         OPENVPN_LOG_TCPLINK_ERROR("TCP packet extract exception: " << e.what());
+				 self->stats->error(err);
+				 self->read_handler->tcp_error_handler(msg);
+				 self->stop();
+			       }
+			     });
+      }
+
+    protected:
+      LinkCommon(ReadHandler read_handler_arg,
+		 typename Protocol::socket& socket_arg,
+		 const size_t send_queue_max_size_arg, // 0 to disable
+		 const size_t free_list_max_size_arg,
+		 const Frame::Context& frame_context_arg,
+		 const SessionStats::Ptr& stats_arg)
+	: socket(socket_arg),
+	  halt(false),
+	  read_handler(read_handler_arg),
+	  frame_context(frame_context_arg),
+	  stats(stats_arg),
+	  send_queue_max_size(send_queue_max_size_arg),
+	  free_list_max_size(free_list_max_size_arg)
+      {
+	set_raw_mode(false);
+      }
+
+#ifdef OPENVPN_GREMLIN
+      void gremlin_config(const Gremlin::Config::Ptr& config)
+      {
+	if (config)
+	  gremlin.reset(new Gremlin::SendRecvQueue(socket.get_executor().context(), config, true));
+      }
+#endif
+
+      bool is_raw_mode() const {
+	return is_raw_mode_read() && is_raw_mode_write();
+      }
+
+      bool is_raw_mode_read() const {
+	if (RAW_MODE_ONLY)
+	  return true;
+	else
+	  return raw_mode_read;
+      }
+
+      bool is_raw_mode_write() const {
+	if (RAW_MODE_ONLY)
+	  return true;
+	else
+	  return raw_mode_write;
+      }
+
+      LinkCommon() { stop(); }
+
+      void queue_send_buffer(BufferPtr& buf)
+      {
+	queue.push_back(std::move(buf));
+	if (queue.size() == 1) // send operation not currently active?
+	  queue_send();
+      }
+
+      void queue_send()
+      {
+	BufferAllocated& buf = *queue.front();
+	socket.async_send(buf.const_buffer_clamp(),
+			  [self=Ptr(this)](const openvpn_io::error_code& error, const size_t bytes_sent)
+			  {
+			    OPENVPN_ASYNC_HANDLER;
+			    self->handle_send(error, bytes_sent);
+			  });
+      }
+
+      void handle_send(const openvpn_io::error_code& error, const size_t bytes_sent)
+      {
+	if (!halt)
+	  {
+	    if (!error)
+	      {
+		OPENVPN_LOG_TCPLINK_VERBOSE("TLS-TCP send raw=" << raw_mode_write << " size=" << bytes_sent);
+		stats->inc_stat(SessionStats::BYTES_OUT, bytes_sent);
+		stats->inc_stat(SessionStats::PACKETS_OUT, 1);
+
+		BufferPtr buf = queue.front();
+		if (bytes_sent == buf->size())
+		  {
+		    queue.pop_front();
+		    if (free_list.size() < free_list_max_size)
+		      {
+			buf->reset_content();
+			free_list.push_back(std::move(buf)); // recycle the buffer for later use
+		      }
+		  }
+		else if (bytes_sent < buf->size())
+		  buf->advance(bytes_sent);
+		else
+		  {
+		    stats->error(Error::TCP_OVERFLOW);
+		    read_handler->tcp_error_handler("TCP_INTERNAL_ERROR"); // error sent more bytes than we asked for
+		    stop();
+		    return;
+		  }
+	      }
+	    else
+	      {
+		OPENVPN_LOG_TCPLINK_ERROR("TLS-TCP send error: " << error.message());
+		stats->error(Error::NETWORK_SEND_ERROR);
+		read_handler->tcp_error_handler("NETWORK_SEND_ERROR");
+		stop();
+		return;
+	      }
+	    if (!queue.empty())
+	      queue_send();
+	    else
+	      tcp_write_queue_needs_send();
+	  }
+      }
+
+      bool process_recv_buffer(BufferAllocated& buf)
+      {
+	bool requeue = true;
+
+	OPENVPN_LOG_TCPLINK_VERBOSE("TLSLink::process_recv_buffer: size=" << buf.size());
+
+	if (!is_raw_mode_read())
+	{
+	  try {
+	    BufferAllocated pkt;
+	    requeue = put_pktstream(buf, pkt);
+	    if (!buf.allocated() && pkt.allocated()) // recycle pkt allocated buffer
+	      buf.move(pkt);
+	  }
+	  catch (const std::exception& e)
+	  {
+	    OPENVPN_LOG_TCPLINK_ERROR("TLS-TCP packet extract error: " << e.what());
+	    stats->error(Error::TCP_SIZE_ERROR);
+	    read_handler->tcp_error_handler("TCP_SIZE_ERROR");
+	    stop();
+	    return false;
+	  }
+	}
+	else
+	{
+	  if (mutate)
+	    mutate->post_recv(buf);
+#ifdef OPENVPN_GREMLIN
+	  if (gremlin)
+	    requeue = gremlin_recv(buf);
+	  else
+#endif
+	  requeue = read_handler->tcp_read_handler(buf);
+	}
+
+	return requeue;
+      }
+
+      void handle_recv(PacketFrom::SPtr pfp, const openvpn_io::error_code& error, const size_t bytes_recvd)
+      {
+	OPENVPN_LOG_TCPLINK_VERBOSE("Link::handle_recv: " << error.message());
+	if (!halt)
+	{
+	  if (!error)
+	  {
+	    recv_buffer(pfp, bytes_recvd);
+	  }
+	  else if (error == openvpn_io::error::eof)
+	  {
+	    OPENVPN_LOG_TCPLINK_ERROR("TCP recv EOF");
+	    read_handler->tcp_eof_handler();
+	  }
+	  else
+	  {
+	    OPENVPN_LOG_TCPLINK_ERROR("TCP recv error: " << error.message());
+	    stats->error(Error::NETWORK_RECV_ERROR);
+	    read_handler->tcp_error_handler("NETWORK_RECV_ERROR");
+	    stop();
+	  }
+	}
+      }
+
+      bool put_pktstream(BufferAllocated& buf, BufferAllocated& pkt)
+      {
+	bool requeue = true;
+	stats->inc_stat(SessionStats::BYTES_IN, buf.size());
+	stats->inc_stat(SessionStats::PACKETS_IN, 1);
+	if (mutate)
+	  mutate->post_recv(buf);
+	while (buf.size())
+	  {
+	    pktstream.put(buf, frame_context);
+	    if (pktstream.ready())
+	      {
+		pktstream.get(pkt);
+#ifdef OPENVPN_GREMLIN
+		if (gremlin)
+		  requeue = gremlin_recv(pkt);
+		else
+#endif
+		requeue = read_handler->tcp_read_handler(pkt);
+	      }
+	  }
+	return requeue;
+      }
+
+#ifdef OPENVPN_GREMLIN
+      void gremlin_queue_send_buffer(BufferPtr& buf)
+      {
+	gremlin->send_queue([self=Ptr(this), buf=std::move(buf)]() mutable {
+	    if (!self->halt)
+	      {
+		self->queue_send_buffer(buf);
+	      }
+	  });
+      }
+
+      bool gremlin_recv(BufferAllocated& buf)
+      {
+	gremlin->recv_queue([self=Ptr(this), buf=std::move(buf)]() mutable {
+	    if (!self->halt)
+	      {
+		const bool requeue = self->read_handler->tcp_read_handler(buf);
+		if (requeue)
+		  self->queue_recv(nullptr);
+	      }
+	  });
+	return false;
+      }
+#endif
+
+      void tcp_write_queue_needs_send()
+      {
+	read_handler->tcp_write_queue_needs_send();
+      }
+
+      typename Protocol::socket& socket;
+      bool halt;
+      ReadHandler read_handler;
+      Frame::Context frame_context;
+      SessionStats::Ptr stats;
+      const size_t send_queue_max_size;
+      const size_t free_list_max_size;
+      Queue queue;      // send queue
+      Queue free_list;  // recycled free buffers for send queue
+      PacketStream pktstream;
+      TransportMutateStream::Ptr mutate;
+      bool raw_mode_read;
+      bool raw_mode_write;
+
+#ifdef OPENVPN_GREMLIN
+      std::unique_ptr<Gremlin::SendRecvQueue> gremlin;
+#endif
+
+    private:
+      virtual void recv_buffer(PacketFrom::SPtr& pfp, const size_t bytes_recvd) = 0;
+      virtual void from_app_send_buffer(BufferPtr& buf) = 0;
+    };
+  }
+} // namespace openvpn
+
+#endif

--- a/openvpn/transport/ptlink.hpp
+++ b/openvpn/transport/ptlink.hpp
@@ -1,4 +1,24 @@
+//    OpenVPN -- An application to securely tunnel IP networks
+//               over a single port, with support for SSL/TLS-based
+//               session authentication and key exchange,
+//               packet encryption, packet authentication, and
+//               packet compression.
+//
 //    Copyright (C) 2012-2020 OpenVPN Inc.
+//
+//    This program is free software: you can redistribute it and/or modify
+//    it under the terms of the GNU Affero General Public License Version 3
+//    as published by the Free Software Foundation.
+//
+//    This program is distributed in the hope that it will be useful,
+//    but WITHOUT ANY WARRANTY; without even the implied warranty of
+//    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+//    GNU Affero General Public License for more details.
+//
+//    You should have received a copy of the GNU Affero General Public License
+//    along with this program in the COPYING file.
+//    If not, see <http://www.gnu.org/licenses/>.
+
 
 // Base class for TCP link objects.
 

--- a/openvpn/transport/ptlink.hpp
+++ b/openvpn/transport/ptlink.hpp
@@ -239,7 +239,7 @@ namespace openvpn {
 	openvpn_io::post([&io_context, connection, mut_buf, completion=std::move(completion)]() mutable {
 	  Error::Type error_code = Error::SUCCESS;
 	  size_t bytes_recvd = 0;
-	  try 
+	  try
 	  {
 	    bytes_recvd = connection->receive(mut_buf);
 	  }
@@ -258,7 +258,7 @@ namespace openvpn {
       }
 
       template <typename Handler>
-      void async_send(openvpn_io::const_buffer buf, Handler&& completion) 
+      void async_send(openvpn_io::const_buffer buf, Handler&& completion)
       {
 	// capture io_context and connection to avoid capturing self. This assumes that completion captures a reference-counted version of self.
 	openvpn_io::io_context& io_context = this->io_context;
@@ -267,7 +267,7 @@ namespace openvpn {
 	openvpn_io::post([&io_context, connection, buf, completion=std::move(completion)]() {
 	  Error::Type error_code = Error::SUCCESS;
 	  size_t bytes_sent = 0;
-	  try 
+	  try
 	  {
 	    bytes_sent = connection->send(buf);
 	  }
@@ -463,7 +463,7 @@ namespace openvpn {
 
       openvpn_io::io_context& io_context;
       openvpn::PluggableTransports::Connection::Ptr connection;
-      
+
       bool halt;
       ReadHandler read_handler;
       Frame::Context frame_context;

--- a/openvpn/transport/ptlink.hpp
+++ b/openvpn/transport/ptlink.hpp
@@ -65,15 +65,14 @@ namespace openvpn {
       BufferAllocated buf;
     };
 
-    template <typename Protocol,
-	      typename ReadHandler>
+    template <typename ReadHandler>
     class LinkImpl : public RC<thread_unsafe_refcount>
     {
       typedef std::deque<BufferPtr> Queue;
 
     public:
-      typedef RCPtr<LinkImpl<Protocol, ReadHandler>> Ptr;
-      typedef Protocol protocol;
+      typedef openvpn_io::ip::tcp protocol;
+      typedef RCPtr<LinkImpl<ReadHandler>> Ptr;
 
       void set_mutate(const TransportMutateStream::Ptr& mutate_arg)
       {


### PR DESCRIPTION
This Pull Requests adds support for a "PluggableTransports" transport layer. It defines a public interface which makes it easy for an implementer to create a new pluggable transport. According to the [pluggable transport spec](https://github.com/Pluggable-Transports/Pluggable-Transports-spec/blob/master/releases/pt-2_0.pdf) we should provide a socket-like interface for ease of implementing the transport itself. I tried to mirror the asio functions as closely as possible, minus the async operations which are handled in the transport link. 

## Implementing and Using a New Pluggable Transport

To create a new transport the implementer must do a few things. 
1. Create new `Transport` and `Client` objects which implement your preferred obfuscation technique. Any configuration should be contained within the `Transport` object. 
2. Compile openvpn3 with `-DOPENVPN_PLUGGABLE_TRANSPORTS` and extend `OpenVPNClient` to implement the `new_transport_factory` method. 
3. Configure the `OpenVPNClient` with the `config.usePluggableTransports` option.

## Why Not Use an External Transport 

In theory it is possible to implement this same functionality with minimal changes to OpenVPN 3 itself, and to use an external transport. This approach would have a few notable downsides: 
1. Everyone who wants to use a pluggable transport would have to implement something equivalent to `ptcli.hpp` and `ptlink.hpp` as an external transport. That's a lot of code just to get obfuscation support. 
2. They would also have to implement the [protocol switching logic](https://github.com/openvpn/openvpn3/blob/master/openvpn/client/cliopt.hpp#L782) in their OpenVPNClient. 

## More Details


The client and link objects are based on the TCP client and link. In this version of the code they handle interfacing with the rest of the OpenVPN code (socket_protect, packet alignment, conforming to the send/receive interface) and also queuing data for the synchronous 'send' calls. The actual 'send' call is provided by the implementer, and may be as simple as a opening a regular TCP socket. While this somewhat complicates the implementation internal to OpenVPN, it simplifies the code for the implementer. 

In theory the client and link can subclass their TCP counterparts so that more code is shared. I consider the refactor this would involve to be out-of-scope for this pull request, at least at the moment. 

## Some Meta Business 

I am submitting this pull request for review through Github for initial review. I will send a patch to the mailing list after I have a few eyes on it. 

I structured this PR to be read commit-by-commit. It might be easier to digest if you look at the diff for each commit. If and when these changes are merged it would be possible to squash them into a single commit - but that's really up to the final reviewers.