### PR TITLE
added xxhash to macos brew install

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -132,7 +132,7 @@ Ensure that [homebrew](https://brew.sh/) is set up.
 
 ::
 
-    $  brew install lz4 openssl cmake asio jsoncpp
+    $  brew install lz4 openssl cmake asio jsoncpp xxhash
 
 Now build the OpenVPN 3 client executable:
 ::


### PR DESCRIPTION
System used to test
---------
OS: `macOS Monteray v12.5.1`
Machine: `Macbook Pro (16-inch 2021)`
Chip: `Apple M1 Pro`
Memory: `16GB`

Error condition
---------
While attempting to follow the build instructions on my dev box I ran into a dependency during the `cmake --build .` command as shown below: 

```bash
 ~/src/build-openvpn3 > cmake --build . 
[  1%] Building CXX object test/unittests/googletest-build/googletest/CMakeFiles/gtest.dir/src/gtest-all.cc.o
[  3%] Linking CXX static library ../../../../lib/libgtest.a
[  3%] Built target gtest
[  5%] Building CXX object test/unittests/googletest-build/googletest/CMakeFiles/gtest_main.dir/src/gtest_main.cc.o
[  6%] Linking CXX static library ../../../../lib/libgtest_main.a
[  6%] Built target gtest_main
[  8%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/core_tests.cpp.o
In file included from /Users/nate/src/openvpn3/test/unittests/core_tests.cpp:30:
In file included from /Users/nate/src/openvpn3/cmake/../openvpn/ssl/sslchoose.hpp:29:
In file included from /Users/nate/src/openvpn3/cmake/../openvpn/openssl/ssl/sslctx.hpp:68:
In file included from /Users/nate/src/openvpn3/cmake/../openvpn/ssl/sslapi.hpp:47:
In file included from /Users/nate/src/openvpn3/cmake/../openvpn/ssl/sess_ticket.hpp:28:
/Users/nate/src/openvpn3/cmake/../openvpn/common/hash.hpp:30:10: fatal error: 'xxhash.h' file not found
#include <xxhash.h>
         ^~~~~~~~~~
1 error generated.
make[2]: *** [test/unittests/CMakeFiles/coreUnitTests.dir/core_tests.cpp.o] Error 1
make[1]: *** [test/unittests/CMakeFiles/coreUnitTests.dir/all] Error 2
make: *** [all] Error 2
```

Install `xxhash` using proposed update
-----------------
```bash
~/src/build-openvpn3 > brew install lz4 openssl cmake asio jsoncpp xxhash 
Warning: Treating cmake as a formula. For the cask, use homebrew/cask/cmake
Warning: lz4 1.9.4 is already installed and up-to-date.
To reinstall 1.9.4, run:
  brew reinstall lz4
Warning: openssl@3 3.0.5 is already installed and up-to-date.
To reinstall 3.0.5, run:
  brew reinstall openssl@3
Warning: cmake 3.24.1 is already installed and up-to-date.
To reinstall 3.24.1, run:
  brew reinstall cmake
Warning: asio 1.24.0 is already installed and up-to-date.
To reinstall 1.24.0, run:
  brew reinstall asio
Warning: jsoncpp 1.9.5 is already installed and up-to-date.
To reinstall 1.9.5, run:
  brew reinstall jsoncpp
==> Downloading https://ghcr.io/v2/homebrew/core/xxhash/manifests/0.8.1
Already downloaded: /Users/nate/Library/Caches/Homebrew/downloads/3a7954ac572d01d9c217fbd991082bf51deef0292b4229055fa760e870015fc7--xxhash-0.8.1.bottle_manifest.json
==> Downloading https://ghcr.io/v2/homebrew/core/xxhash/blobs/sha256:6e4991033c6714cb11fc90c0996431c9aedcd141c7bfc0238c67be3f50515b1a
Already downloaded: /Users/nate/Library/Caches/Homebrew/downloads/4c8cfed89276773a227c67e4c69258e5dbf407d9cbe1984f225fc3ea9a787eed--xxhash--0.8.1.arm64_monterey.bottle.tar.gz
==> Pouring xxhash--0.8.1.arm64_monterey.bottle.tar.gz
🍺  /Users/nate/homebrew/Cellar/xxhash/0.8.1: 17 files, 399.4KB
==> Running `brew cleanup xxhash`...
Disable this behaviour by setting HOMEBREW_NO_INSTALL_CLEANUP.
Hide these hints with HOMEBREW_NO_ENV_HINTS (see `man brew`).
```

`cmake --build .` command succeeded
-----------------------------------------
```bash
~/src/build-openvpn3 > cmake --build . 
Consolidate compiler generated dependencies of target gtest
[  3%] Built target gtest
Consolidate compiler generated dependencies of target gtest_main
[  6%] Built target gtest_main
[  8%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/core_tests.cpp.o
[ 10%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_route_emulation.cpp.o
[ 11%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_log.cpp.o
[ 13%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_comp.cpp.o
[ 15%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_b64.cpp.o
[ 16%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_verify_x509_name.cpp.o
[ 18%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_ssl.cpp.o
[ 20%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_continuation.cpp.o
[ 21%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_crypto.cpp.o
[ 23%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_optfilt.cpp.o
[ 25%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_pktstream.cpp.o
[ 26%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_remotelist.cpp.o
[ 28%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_http_proxy.cpp.o
[ 30%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_peer_fingerprint.cpp.o
[ 31%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_safestr.cpp.o
[ 33%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_dns.cpp.o
[ 35%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_header_deps.cpp.o
[ 36%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_capture.cpp.o
[ 38%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_cleanup.cpp.o
[ 40%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_crypto_hashstr.cpp.o
[ 41%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_csum.cpp.o
[ 43%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_format.cpp.o
[ 45%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_headredact.cpp.o
[ 46%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_hostport.cpp.o
[ 48%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_ip.cpp.o
[ 50%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_parseargv.cpp.o
[ 51%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_path.cpp.o
[ 53%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_pktid.cpp.o
[ 55%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_prefixlen.cpp.o
[ 56%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_rc.cpp.o
[ 58%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_route.cpp.o
[ 60%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_statickey.cpp.o
[ 61%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_streq.cpp.o
[ 63%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_time.cpp.o
[ 65%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_typeindex.cpp.o
[ 66%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_validatecreds.cpp.o
[ 68%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_weak.cpp.o
[ 70%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_openssl_x509certinfo.cpp.o
[ 71%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_opensslpki.cpp.o
[ 73%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_session_id.cpp.o
[ 75%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_buffer_ip.cpp.o
[ 76%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_cpu_time.cpp.o
[ 78%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_misc_unix.cpp.o
[ 80%] Building CXX object test/unittests/CMakeFiles/coreUnitTests.dir/test_pipe.cpp.o
[ 81%] Linking CXX executable coreUnitTests
[ 81%] Built target coreUnitTests
[ 83%] Building C object test/ovpncli/CMakeFiles/xkey.dir/__/__/openvpn/openssl/xkey/xkey_helper.c.o
[ 85%] Building C object test/ovpncli/CMakeFiles/xkey.dir/__/__/openvpn/openssl/xkey/xkey_provider.c.o
[ 86%] Linking C static library libxkey.a
[ 86%] Built target xkey
[ 88%] Building CXX object test/ovpncli/CMakeFiles/ovpncli.dir/cli.cpp.o
[ 90%] Linking CXX executable ovpncli
[ 90%] Built target ovpncli
[ 91%] Building CXX object test/ovpncli/CMakeFiles/ovpncliagent.dir/cli.cpp.o
[ 93%] Linking CXX executable ovpncliagent
[ 93%] Built target ovpncliagent
[ 95%] Building CXX object test/ssl/CMakeFiles/proto.dir/proto.cpp.o
[ 96%] Linking CXX executable proto
[ 96%] Built target proto
[ 98%] Building CXX object openvpn/ovpnagent/mac/CMakeFiles/agent_macos.dir/ovpnagent.cpp.o
[100%] Linking CXX executable agent_macos
[100%] Built target agent_macos
```




