### PR TITLE
Fix issue where allow_local_dns_resolvers isn't passed to tunnel.

### DIFF
--- a/openvpn/client/cliopt.hpp
+++ b/openvpn/client/cliopt.hpp
@@ -471,6 +471,7 @@ namespace openvpn {
 	    tunconf->stats = cli_stats;
 	    tunconf->stop = config.stop;
 	    tunconf->tun_type = config.wintun ? TunWin::Wintun : TunWin::TapWindows6;
+      tunconf->allow_local_dns_resolvers = config.allow_local_dns_resolvers;
 	    if (config.tun_persist)
 	      {
 		tunconf->tun_persist.reset(new TunWin::TunPersist(true, TunWrapObjRetain::NO_RETAIN, nullptr));

--- a/openvpn/client/cliopt.hpp
+++ b/openvpn/client/cliopt.hpp
@@ -471,7 +471,7 @@ namespace openvpn {
 	    tunconf->stats = cli_stats;
 	    tunconf->stop = config.stop;
 	    tunconf->tun_type = config.wintun ? TunWin::Wintun : TunWin::TapWindows6;
-      tunconf->allow_local_dns_resolvers = config.allow_local_dns_resolvers;
+      	    tunconf->allow_local_dns_resolvers = config.allow_local_dns_resolvers;
 	    if (config.tun_persist)
 	      {
 		tunconf->tun_persist.reset(new TunWin::TunPersist(true, TunWrapObjRetain::NO_RETAIN, nullptr));


### PR DESCRIPTION
Im not really sure how to describe this issue. But when I set `config.allowLocalDnsResolvers = true;` allow_local_dns_resolvers is still false.

log:
```
[Mon Nov 28 14:10:28 2022] SetupClient: transmitting tun setup list to \\.\pipe\ovpnagent
{
        "allow_local_dns_resolvers" : false, <-- but, config.allowLocalDnsResolvers = true;
        "confirm_event" : "6c0d000000000000",
        "destroy_event" : "480d000000000000",
        "tun" :
        {
                "adapter_domain_suffix" : "",
                "block_ipv6" : false,
                "dns_servers" :
                [
                        {
                                "address" : "8.8.8.8",
                                "ipv6" : false
                        },
                        {
                                "address" : "8.8.4.4",
                                "ipv6" : false
                        }
                ],
                "layer" : 3,
                "mtu" : 0,
                "remote_address" :
                {
                        "address" : "ip",
                        "ipv6" : false
                },
                "reroute_gw" :
                {
                        "flags" : 275,
                        "ipv4" : true,
                        "ipv6" : false
                },
                "route_metric_default" : -1,
                "session_name" : "#",
                "tunnel_address_index_ipv4" : 0,
                "tunnel_address_index_ipv6" : -1,
                "tunnel_addresses" :
                [
                        {
                                "address" : "10.43.32.6",
                                "gateway" : "10.43.32.1",
                                "ipv6" : false,
                                "metric" : -1,
                                "net30" : false,
                                "prefix_length" : 24
                        }
                ]
        },
        "tun_type" : 0
}
```
I managed to figure it out and it was a pretty easy fix. just had to define `tunconf->allow_local_dns_resolvers`
