### PR TITLE
Add 'pull' to ignored options

### DIFF
--- a/openvpn/client/cliopt.hpp
+++ b/openvpn/client/cliopt.hpp
@@ -797,6 +797,7 @@ class ClientOptions : public RC<thread_unsafe_refcount>
         "mute-replay-warnings",
         "nobind", /* only behaviour in v3 client anyway */
         "prng",
+        "pull", /* option is implied by 'client' */
         "rcvbuf",         /* present in many configs */
         "replay-persist", /* Makes little sense in TLS mode */
         "script-security",


### PR DESCRIPTION
Fixes error that --pull is a unknown option in client config.

This fixes #277 