### PR TITLE
Fix error connecting from IPv6 only network

### DIFF
--- a/openvpn/tun/win/client/tunsetup.hpp
+++ b/openvpn/tun/win/client/tunsetup.hpp
@@ -548,7 +548,8 @@ class Setup : public SetupBase
         if (pull.reroute_gw.ipv4)
         {
             // get default gateway
-            const Util::BestGateway gw{AF_INET, pull.remote_address.address, tap.index};
+            const ADDRESS_FAMILY af = pull.remote_address.ipv6 ? AF_INET6 : AF_INET;
+            const Util::BestGateway gw{af, pull.remote_address.address, tap.index};
 
             if (!gw.local_route())
             {


### PR DESCRIPTION
The following error occurred when I tried to connect from the IPv6-only network to IPv4 server using Windows client:
```
[Aug 8, 2023, 18:10:44] SetupClient: transmitting tun setup list to \\.\pipe\agent_ovpnconnect
{
	"allow_local_dns_resolvers" : false,
	"confirm_event" : "4412000000000000",
	"destroy_event" : "4812000000000000",
	"tun" : 
	{
		"adapter_domain_suffix" : "",
		"block_ipv6" : false,
		"dns_servers" : 
		[
			{
				"address" : "192.168.88.1",
				"ipv6" : false
			}
		],
		"layer" : 3,
		"mtu" : 0,
		"remote_address" : 
		{
			"address" : "<CENSORED>5f9e:ed1",
			"ipv6" : true
		},
		"reroute_gw" : 
		{
			"flags" : 275,
			"ipv4" : true,
			"ipv6" : false
		},
		"route_metric_default" : -1,
		"session_name" : "<CENSORED>5f9e:ed1",
		"tunnel_address_index_ipv4" : 0,
		"tunnel_address_index_ipv6" : -1,
		"tunnel_addresses" : 
		[
			{
				"address" : "192.168.89.245",
				"gateway" : "192.168.89.1",
				"ipv6" : false,
				"metric" : -1,
				"net30" : false,
				"prefix_length" : 24
			}
		]
	},
	"tun_type" : 0
}
POST np://[\\.\pipe\agent_ovpnconnect]/tun-setup : 400 Bad Request
TAP ADAPTERS:
guid='{55563F47-FA49-4A0A-A294-987DA449FB71}' index=85 name='Local Area Connection'
Open TAP device "Local Area Connection" PATH="\\.\Global\{55563F47-FA49-4A0A-A294-987DA449FB71}.tap" SUCCEEDED
TAP-Windows Driver Version 9.26
Destroyed previous TAP instance due to exception
ip_exception: to_ipv4: address is not IPv4
```