### PR TITLE
fix: use `#!/usr/bin/env bash`

### DIFF
--- a/deps/mbedtls/build-mbedtls
+++ b/deps/mbedtls/build-mbedtls
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 if [ -z "$O3" ]; then

--- a/scripts/version
+++ b/scripts/version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #    OpenVPN -- An application to securely tunnel IP networks
 #               over a single port, with support for SSL/TLS-based

--- a/test/ovpncli/go
+++ b/test/ovpncli/go
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # Options:
 #   OSSL=1    -- build using OpenSSL


### PR DESCRIPTION
# Description

This replaces `/bin/bash` shebang with a more universal `/usr/bin/env bash`.

This is required for easier packaging in systems which don't provide the former such as NixOS.
