### PR TITLE
build: make scripts sh-compatible

### DIFF
--- a/deps/mbedtls/build-mbedtls
+++ b/deps/mbedtls/build-mbedtls
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 set -e
 if [ -z "$O3" ]; then
@@ -20,11 +20,11 @@ if [ -z "$TARGET" ]; then
 fi
 
 # source vars
-. $O3/core/vars/vars-${TARGET}
-. $O3/core/deps/lib-versions
+. "$O3/core/vars/vars-${TARGET}"
+. "$O3/core/deps/lib-versions"
 
 # source helper functions
-. $O3/core/deps/functions.sh
+. "$O3/core/deps/functions.sh"
 
 FNAME=${MBEDTLS_VERSION}.tar.gz
 PN=${MBEDTLS_VERSION#*-}
@@ -35,29 +35,29 @@ download
 
 # put build targets here
 DIST=$(pwd)/mbedtls/mbedtls-$PLATFORM
-rm -rf $DIST
-mkdir -p $DIST
+rm -rf "$DIST"
+mkdir -p "$DIST"
 
 if [ "$NO_WIPE" = "1" ]; then
     echo RETAIN existing source
-    cd $MBEDTLS_VERSION
+    cd "$MBEDTLS_VERSION"
 else
     echo WIPE and reunzip source
-    rm -rf $MBEDTLS_VERSION
+    rm -rf "$MBEDTLS_VERSION"
     [ -z "$DL" ] && DL=~/Downloads
-    tar xfz $DL/$MBEDTLS_VERSION.tar.gz
-    cd $MBEDTLS_VERSION
+    tar xfz "$DL/$MBEDTLS_VERSION.tar.gz"
+    cd "$MBEDTLS_VERSION"
 
     # enable MD4 (needed for NTLM auth)
     perl -pi -e 's/^\/\/// if /#define MBEDTLS_MD4_C/' include/mbedtls/config.h
 fi
 
-if [ "x$NO_BUILD" == x1 ]; then
+if [ "$NO_BUILD" = 1 ]; then
    echo "Not building"
    exit 0
 fi
 
-if [[ "x$TARGET" == xlinux* || "x$TARGET" == xosx* ]]; then
+if echo "$TARGET" | grep -q '^linux.*$' || echo "$TARGET" | grep -q '^osx.*$'; then
     # run unit tests and then clean
     echo RUNNING CHECK
     make check
@@ -80,21 +80,21 @@ RANLIB=ranlib
 # build it
 SRC=$(pwd)
 cd library
-rm -f *.o
+rm -f ./*.o
 for c in *.c ; do
     CMD="$CC -I../include -DMBEDTLS_RELAXED_X509_DATE \
-         $PLATFORM_FLAGS $(lto_flags $c) $OTHER_COMPILER_FLAGS $LIB_OPT_LEVEL $LIB_FPIC -c $c"
-    echo $CMD
+         $PLATFORM_FLAGS $(lto_flags "$c") $OTHER_COMPILER_FLAGS $LIB_OPT_LEVEL $LIB_FPIC -c $c"
+    echo "$CMD"
     $CMD
 done
 
 # create archive
-cd $DIST
+cd "$DIST"
 mkdir library
-$AR library/libmbedtls.a $SRC/library/*.o
+$AR library/libmbedtls.a "$SRC/library/"*.o
 $RANLIB library/libmbedtls.a 2>&1 | grep -v "has no symbols" || true
 
 # copy headers
 mkdir -p include/mbedtls
-cp $SRC/include/mbedtls/*.h include/mbedtls/
+cp "$SRC/include/mbedtls/"*.h include/mbedtls/
 exit 0

--- a/scripts/version
+++ b/scripts/version
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 #    OpenVPN -- An application to securely tunnel IP networks
 #               over a single port, with support for SSL/TLS-based
@@ -25,7 +25,8 @@ set -eu
 
 # ensure this script works even when core is used as submodule, by setting
 # O3/core/.git as git folder
-export GIT_DIR=$(dirname $0)/../.git
+GIT_DIR=$(dirname "$0")/../.git
+export GIT_DIR
 
 MAJOR=3
 BRANCH="$(git rev-parse --symbolic-full-name HEAD | cut -d/ -f3- | tr / _)"

--- a/test/ovpncli/go
+++ b/test/ovpncli/go
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Options:
 #   OSSL=1    -- build using OpenSSL
@@ -14,6 +14,7 @@ GCC_EXTRA="$GCC_EXTRA -DOPENVPN_SHOW_SESSION_TOKEN"
 [ "$DEX" = "1" ] && GCC_EXTRA="$GCC_EXTRA -DOPENVPN_DISABLE_EXPLICIT_EXIT"
 [ "$BS64" = "1" ] && GCC_EXTRA="$GCC_EXTRA -DOPENVPN_BS64_DATA_LIMIT=2500000"
 [ "$ROVER" = "1" ] && GCC_EXTRA="$GCC_EXTRA -DOPENVPN_REMOTE_OVERRIDE"
+# shellcheck disable=SC2153
 [ "$TLS" = "1" ] && GCC_EXTRA="$GCC_EXTRA -DOPENVPN_TLS_LINK"
 [ "$SITNL" = "1" ] && GCC_EXTRA="$GCC_EXTRA -DOPENVPN_USE_SITNL"
 [ "$MDNC" = "1" ] && GCC_EXTRA="$GCC_EXTRA -DMBEDTLS_DISABLE_NAME_CONSTRAINTS"
@@ -21,20 +22,22 @@ GCC_EXTRA="$GCC_EXTRA -DOPENVPN_SHOW_SESSION_TOKEN"
 if [ "$AGENT" = "1" ]; then
     GCC_EXTRA="$GCC_EXTRA -DOPENVPN_COMMAND_AGENT"
 fi
-GCC_EXTRA="$GCC_EXTRA -DOPENVPN_VERSION=\"$($(dirname $0)/../../scripts/version)\""
+# shellcheck disable=SC2046,SC2089
+GCC_EXTRA="$GCC_EXTRA -DOPENVPN_VERSION=\"$($(dirname "$0")/../../scripts/version)\""
+# shellcheck disable=SC2090
 export GCC_EXTRA
 
 # determine platform
-if [ "$(uname)" == "Darwin" ]; then
-    export PROF=${PROF:-osx64}
-elif [ "$(uname)" == "Linux" ]; then
-    export PROF=${PROF:-linux}
+if [ "$(uname)" = "Darwin" ]; then
+    export PROF="${PROF:-osx64}"
+elif [ "$(uname)" = "Linux" ]; then
+    export PROF="${PROF:-linux}"
 else
     echo this script only knows how to build on Mac OS or Linux
 fi
 
 # use mbedTLS by default
-[[ -z "$OSSL" && -z "$MTLS" ]] && export MTLS=1
+[ -z "$OSSL" ] && [ -z "$MTLS" ] && export MTLS=1
 
 # don't link with OpenSSL if mbedTLS is specified
 if [ "$MTLS" = "1" ]; then


### PR DESCRIPTION
# Description

This is another approach to #315 which aims at making scripts more portable.

In order to ensure compatibility I've tried to resolve all [shellcheck] warnings with the exception of building `GCC_EXTRA` for which there seems to be mo simple transition.

[shellcheck]: https://www.shellcheck.net/
