### PR TITLE
Update LICENSE.rst: typo, which led to broken link

### DIFF
--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,5 +1,5 @@
 OpenVPN 3 is distributed under 
-`GNU Affero General Public License version 3 <LICENSES/APGL-3.0-only.txt>`_
+`GNU Affero General Public License version 3 <LICENSES/AGPL-3.0-only.txt>`_
 or
 `Mozilla Public License Version 2.0 <LICENSES/MPL-2.0.txt>` _
 


### PR DESCRIPTION
https://github.com/OpenVPN/openvpn3/blob/master/LICENSES/APGL-3.0-only.txt returns 404