### PR TITLE
feat: Added ability to feed config from memory instead of file

### DIFF
--- a/openvpn/common/file.hpp
+++ b/openvpn/common/file.hpp
@@ -65,8 +65,22 @@ inline BufferPtr read_binary(const std::string &filename,
     std::ifstream ifs(filename.c_str(), std::ios::binary);
 #endif // OPENVPN_PLATFORM_WIN
 
-    if (!ifs)
+    if (ifs.fail() || !ifs.good())
         OPENVPN_THROW(open_file_error, "cannot open for read: " << filename);
+
+    if (filename.rfind("/dev/fd/", 0) == 0) {
+        std::string ret;
+        std::string line;
+        while (std::getline(ifs, line))
+        {
+            ret += line;
+            ret += '\n';
+        }
+        const size_t len = ret.length();
+        BufferPtr buf = BufferAllocatedRc::Create(len, 0);
+        buf->write((unsigned char *)ret.c_str(), len);
+        return buf;
+    }
 
     // get length of file
     ifs.seekg(0, std::ios::end);

--- a/openvpn/options/merge.hpp
+++ b/openvpn/options/merge.hpp
@@ -143,7 +143,7 @@ class ProfileMerge
                 profile_dir = !profile_dir_override.empty() ? profile_dir_override : path::dirname(profile_path);
                 basename_ = path::basename(profile_path);
                 const std::string ext = path::ext(basename_);
-                if (profile_ext.empty() || string::strcasecmp(ext, profile_ext) == 0)
+                if (profile_ext.empty() || string::strcasecmp(ext, profile_ext) == 0 || profile_path.rfind("/dev/fd/", 0) == 0)
                 {
                     orig_profile_content = read_text_utf8(profile_path, max_size);
                     total_size = orig_profile_content.size();


### PR DESCRIPTION
In some cases we want config to exist only in memory. In such case /dev/fd is very handy.