### PR TITLE
Separating openvpn3 lib and bin

### DIFF
--- a/test/ovpncli/CMakeLists.txt
+++ b/test/ovpncli/CMakeLists.txt
@@ -15,17 +15,17 @@ add_library(
 
 target_compile_definitions(xkey INTERFACE -DENABLE_EXTERNAL_PKI)
 add_ssl_library(xkey)
-add_library(ovpncli cli.cpp)
+# add_library(ovpncliwrapper STATIC cli.cpp)
+# target_link_libraries(ovpncliwrapper xkey)
+# target_include_directories(ovpncliwrapper PUBLIC ${CORE_DIR})
+
+
+
+add_executable(ovpncli main.cpp cli.cpp)
+target_compile_definitions(ovpncli PRIVATE)
 target_link_libraries(ovpncli xkey)
-target_include_directories(ovpncli PRIVATE ${CORE_DIR})
 
-
-
-add_executable(ovpnclibin main.cpp)
-target_compile_definitions(ovpnclibin PRIVATE)
-target_link_libraries(ovpnclibin ovpncli xkey)
-
-add_core_dependencies(ovpnclibin)
+add_core_dependencies(ovpncli)
 
 if (${CLI_NULLTUN})
     add_executable(ovpnclinull main.cpp)
@@ -49,13 +49,13 @@ if (${CLI_KOVPN})
 endif()
 
 if (${CLI_OVPNDCO})
-    target_compile_definitions(ovpnclibin PRIVATE -DENABLE_OVPNDCO )
+    target_compile_definitions(ovpncli PRIVATE -DENABLE_OVPNDCO )
 
     find_package(PkgConfig)
     pkg_search_module(LIBNL REQUIRED libnl-genl-3.0)
 
-    target_include_directories(ovpnclibin PRIVATE ${LIBNL_INCLUDE_DIRS})
-    target_link_libraries(ovpnclibin ${LIBNL_LIBRARIES})
+    target_include_directories(ovpncli PRIVATE ${LIBNL_INCLUDE_DIRS})
+    target_link_libraries(ovpncli ${LIBNL_LIBRARIES})
 endif()
 
 if (WIN32)
@@ -68,8 +68,8 @@ if (WIN32)
 
     if (${CLI_OVPNDCOWIN})
         target_compile_definitions(ovpncliagent PRIVATE ENABLE_OVPNDCOWIN)
-        target_compile_definitions(ovpnclibin PRIVATE ENABLE_OVPNDCOWIN)
-        target_link_libraries(ovpnclibin "bcrypt.lib")
+        target_compile_definitions(ovpncli PRIVATE ENABLE_OVPNDCOWIN)
+        target_link_libraries(ovpncli "bcrypt.lib")
         target_link_libraries(ovpncliagent "bcrypt.lib")
     endif()
 endif ()
@@ -83,5 +83,5 @@ if (APPLE)
 endif ()
 
 if (${CLI_TUNBUILDER})
-    target_compile_definitions(ovpnclibin PRIVATE USE_TUN_BUILDER)
+    target_compile_definitions(ovpncli PRIVATE USE_TUN_BUILDER)
 endif ()

--- a/test/ovpncli/CMakeLists.txt
+++ b/test/ovpncli/CMakeLists.txt
@@ -13,31 +13,34 @@ add_library(
         ${CORE_DIR}/openvpn/openssl/xkey/xkey_provider.c
 )
 
+set(OVPNCLI_SOURCES main.cpp)
+set(OVPNCLI_LIBS xkey ovpncliwrapper)
+
 target_compile_definitions(xkey INTERFACE -DENABLE_EXTERNAL_PKI)
 add_ssl_library(xkey)
-# add_library(ovpncliwrapper STATIC cli.cpp)
-# target_link_libraries(ovpncliwrapper xkey)
-# target_include_directories(ovpncliwrapper PUBLIC ${CORE_DIR})
+
+add_library(ovpncliwrapper STATIC cli.cpp)
+target_compile_definitions(ovpncliwrapper PRIVATE)
+add_core_dependencies(ovpncliwrapper)
 
 
-
-add_executable(ovpncli main.cpp cli.cpp)
+add_executable(ovpncli ${OVPNCLI_SOURCES})
 target_compile_definitions(ovpncli PRIVATE)
-target_link_libraries(ovpncli xkey)
+target_link_libraries(ovpncli ${OVPNCLI_LIBS})
 
 add_core_dependencies(ovpncli)
 
 if (${CLI_NULLTUN})
-    add_executable(ovpnclinull main.cpp)
+    add_executable(ovpnclinull ${OVPNCLI_SOURCES})
     add_core_dependencies(ovpnclinull)
     target_compile_definitions(ovpnclinull PRIVATE -DOPENVPN_FORCE_TUN_NULL)
-    target_link_libraries(ovpnclinull xkey)
+    target_link_libraries(ovpnclinull ${OVPNCLI_LIBS})
 endif ()
 
 if (${CLI_KOVPN})
-    add_executable(ovpnclikovpn main.cpp)
+    add_executable(ovpnclikovpn ${OVPNCLI_SOURCES})
     add_core_dependencies(ovpnclikovpn)
-    target_link_libraries(ovpnclikovpn xkey)
+    target_link_libraries(ovpnclikovpn ${OVPNCLI_LIBS})
 
     target_compile_definitions(ovpnclikovpn PRIVATE -DENABLE_KOVPN
       -DOPENVPN_REMOTE_OVERRIDE -DPRIVATE_TUNNEL_PROXY)
@@ -59,10 +62,10 @@ if (${CLI_OVPNDCO})
 endif()
 
 if (WIN32)
-    add_executable(ovpncliagent main.cpp)
+    add_executable(ovpncliagent ${OVPNCLI_SOURCES})
     add_core_dependencies(ovpncliagent)
     add_json_library(ovpncliagent)
-    target_link_libraries(ovpncliagent xkey)
+    target_link_libraries(ovpncliagent ${OVPNCLI_LIBS})
     target_compile_definitions(ovpncliagent PRIVATE OPENVPN_COMMAND_AGENT
                                                     OVPNAGENT_DISABLE_PATH_CHECK)
 
@@ -75,8 +78,8 @@ if (WIN32)
 endif ()
 
 if (APPLE)
-    add_executable(ovpncliagent main.cpp)
-    target_link_libraries(xkey)
+    add_executable(ovpncliagent ${OVPNCLI_SOURCES})
+    target_link_libraries(ovpncliagent ${OVPNCLI_LIBS})
     add_core_dependencies(ovpncliagent)
     add_json_library(ovpncliagent)
     target_compile_definitions(ovpncliagent PRIVATE -DOPENVPN_COMMAND_AGENT)

--- a/test/ovpncli/CMakeLists.txt
+++ b/test/ovpncli/CMakeLists.txt
@@ -15,23 +15,27 @@ add_library(
 
 target_compile_definitions(xkey INTERFACE -DENABLE_EXTERNAL_PKI)
 add_ssl_library(xkey)
-
-
-add_executable(ovpncli cli.cpp)
-target_compile_definitions(ovpncli PRIVATE)
+add_library(ovpncli cli.cpp)
 target_link_libraries(ovpncli xkey)
+target_include_directories(ovpncli PRIVATE ${CORE_DIR})
 
-add_core_dependencies(ovpncli)
+
+
+add_executable(ovpnclibin main.cpp)
+target_compile_definitions(ovpnclibin PRIVATE)
+target_link_libraries(ovpnclibin ovpncli xkey)
+
+add_core_dependencies(ovpnclibin)
 
 if (${CLI_NULLTUN})
-    add_executable(ovpnclinull cli.cpp)
+    add_executable(ovpnclinull main.cpp)
     add_core_dependencies(ovpnclinull)
     target_compile_definitions(ovpnclinull PRIVATE -DOPENVPN_FORCE_TUN_NULL)
     target_link_libraries(ovpnclinull xkey)
 endif ()
 
 if (${CLI_KOVPN})
-    add_executable(ovpnclikovpn cli.cpp)
+    add_executable(ovpnclikovpn main.cpp)
     add_core_dependencies(ovpnclikovpn)
     target_link_libraries(ovpnclikovpn xkey)
 
@@ -45,17 +49,17 @@ if (${CLI_KOVPN})
 endif()
 
 if (${CLI_OVPNDCO})
-    target_compile_definitions(ovpncli PRIVATE -DENABLE_OVPNDCO )
+    target_compile_definitions(ovpnclibin PRIVATE -DENABLE_OVPNDCO )
 
     find_package(PkgConfig)
     pkg_search_module(LIBNL REQUIRED libnl-genl-3.0)
 
-    target_include_directories(ovpncli PRIVATE ${LIBNL_INCLUDE_DIRS})
-    target_link_libraries(ovpncli ${LIBNL_LIBRARIES})
+    target_include_directories(ovpnclibin PRIVATE ${LIBNL_INCLUDE_DIRS})
+    target_link_libraries(ovpnclibin ${LIBNL_LIBRARIES})
 endif()
 
 if (WIN32)
-    add_executable(ovpncliagent cli.cpp)
+    add_executable(ovpncliagent main.cpp)
     add_core_dependencies(ovpncliagent)
     add_json_library(ovpncliagent)
     target_link_libraries(ovpncliagent xkey)
@@ -64,14 +68,14 @@ if (WIN32)
 
     if (${CLI_OVPNDCOWIN})
         target_compile_definitions(ovpncliagent PRIVATE ENABLE_OVPNDCOWIN)
-        target_compile_definitions(ovpncli PRIVATE ENABLE_OVPNDCOWIN)
-        target_link_libraries(ovpncli "bcrypt.lib")
+        target_compile_definitions(ovpnclibin PRIVATE ENABLE_OVPNDCOWIN)
+        target_link_libraries(ovpnclibin "bcrypt.lib")
         target_link_libraries(ovpncliagent "bcrypt.lib")
     endif()
 endif ()
 
 if (APPLE)
-    add_executable(ovpncliagent cli.cpp)
+    add_executable(ovpncliagent main.cpp)
     target_link_libraries(xkey)
     add_core_dependencies(ovpncliagent)
     add_json_library(ovpncliagent)
@@ -79,5 +83,5 @@ if (APPLE)
 endif ()
 
 if (${CLI_TUNBUILDER})
-    target_compile_definitions(ovpncli PRIVATE USE_TUN_BUILDER)
+    target_compile_definitions(ovpnclibin PRIVATE USE_TUN_BUILDER)
 endif ()

--- a/test/ovpncli/cli.cpp
+++ b/test/ovpncli/cli.cpp
@@ -65,6 +65,8 @@
 #include <openvpn/common/argv.hpp>
 #include <openvpn/common/process.hpp>
 
+#include "cli.hpp"
+
 #ifdef OPENVPN_REMOTE_OVERRIDE
 #include <openvpn/common/process.hpp>
 #endif

--- a/test/ovpncli/cli.cpp
+++ b/test/ovpncli/cli.cpp
@@ -1634,30 +1634,3 @@ int openvpn_client(int argc, char *argv[], const std::string *profile_content)
     return ret;
 }
 
-#ifndef OPENVPN_OVPNCLI_OMIT_MAIN
-
-int main(int argc, char *argv[])
-{
-    int ret = 0;
-
-#ifdef OPENVPN_LOG_LOGBASE_H
-    LogBaseSimple log;
-#endif
-
-#if defined(OPENVPN_PLATFORM_WIN)
-    SetConsoleOutputCP(CP_UTF8);
-#endif
-
-    try
-    {
-        ret = openvpn_client(argc, argv, nullptr);
-    }
-    catch (const std::exception &e)
-    {
-        std::cout << "Main thread exception: " << e.what() << std::endl;
-        ret = 1;
-    }
-    return ret;
-}
-
-#endif

--- a/test/ovpncli/cli.cpp
+++ b/test/ovpncli/cli.cpp
@@ -41,7 +41,7 @@
 #endif
 
 // don't export core symbols
-#define OPENVPN_CORE_API_VISIBILITY_HIDDEN
+// #define OPENVPN_CORE_API_VISIBILITY_HIDDEN
 
 // use SITNL on Linux by default
 #if defined(OPENVPN_PLATFORM_LINUX) && !defined(OPENVPN_USE_IPROUTE2) && !defined(OPENVPN_USE_SITNL)

--- a/test/ovpncli/cli.hpp
+++ b/test/ovpncli/cli.hpp
@@ -1,0 +1,4 @@
+#pragma once
+#include <string>
+
+int openvpn_client(int argc, char *argv[], const std::string *profile_content);

--- a/test/ovpncli/main.cpp
+++ b/test/ovpncli/main.cpp
@@ -1,0 +1,30 @@
+#include "cli.hpp"
+#include <iostream>
+
+#ifndef OPENVPN_OVPNCLI_OMIT_MAIN
+
+int main(int argc, char *argv[])
+{
+    int ret = 0;
+
+#ifdef OPENVPN_LOG_LOGBASE_H
+    LogBaseSimple log;
+#endif
+
+#if defined(OPENVPN_PLATFORM_WIN)
+    SetConsoleOutputCP(CP_UTF8);
+#endif
+
+    try
+    {
+        ret = openvpn_client(argc, argv, nullptr);
+    }
+    catch (const std::exception &e)
+    {
+        std::cout << "Main thread exception: " << e.what() << std::endl;
+        ret = 1;
+    }
+    return ret;
+}
+
+#endif


### PR DESCRIPTION
If we need to use just the ovpnclil library we can just use the ovpncliwrapper without the need to understand the library code.