### PR TITLE
docs: add missing `fmt` dependency for building on Mac OS

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Install the dependencies:
 
 Ensure that [homebrew](<https://brew.sh/>) is set up.
 
-    $  brew install asio cmake jsoncpp lz4 openssl pkg-config xxhash
+    $  brew install asio cmake jsoncpp lz4 openssl pkg-config xxhash fmt
 
 Now build the OpenVPN 3 client executable:
 


### PR DESCRIPTION
I am building OpenVPN 3 for Mac OS and noticed that there is a missing dependency that needs to be installed with Homebrew. This adds it to the `brew install` command in the README