### PR TITLE
feature: management interface compiles on macos

### DIFF
--- a/openvpn/omi/CMakeLists.txt
+++ b/openvpn/omi/CMakeLists.txt
@@ -1,9 +1,16 @@
+option(CLI_OVPNDCOWIN "Build ovpncli with ovpn-dco-win driver support" OFF)
+if (APPLE)
+
+  add_executable(omicliagent_macos openvpn.cpp)
+  add_core_dependencies(omicliagent_macos)
+  add_json_library(omicliagent_macos)
+  target_compile_options(omicliagent_macos PRIVATE -Wno-deprecated-declarations)
+  target_compile_definitions(omicliagent_macos PRIVATE -DOPENVPN_COMMAND_AGENT)
+  return()
+endif()
 if (NOT WIN32)
   return()
 endif()
-
-option(CLI_OVPNDCOWIN "Build ovpncli with ovpn-dco-win driver support" OFF)
-
 add_executable(omicliagent openvpn.cpp)
 add_core_dependencies(omicliagent)
 add_json_library(omicliagent)


### PR DESCRIPTION
The OpenVPN management Interface was designed such that it compiled only on Windows. I have modified the CMakeLists so that it compiles on macOS as well, and the openvpn.cpp so that it ignores the Windows-only functions that are not required on macOs. 