### PR TITLE
fix: add built in baseline to windows manifest

### DIFF
--- a/deps/vcpkg_manifests/windows/vcpkg.json
+++ b/deps/vcpkg_manifests/windows/vcpkg.json
@@ -2,6 +2,7 @@
     "$schema": "https://raw.githubusercontent.com/microsoft/vcpkg/master/scripts/vcpkg.schema.json",
     "name": "openvpn3",
     "version-string": "3.11",
+    "builtin-baseline":"d1ff36c6520ee43f1a656c03cd6425c2974a449e",
     "dependencies": [
         "asio",
         "fmt",


### PR DESCRIPTION
The vcpkg.json manifest file required the builtin-baseline to be mentioned. Without that, the code was not getting built using msvc. I checked the msbuild.yml file which is used for building OpenVPN for Windows systems on this repository. I copied the version from there and updated the vcpkg.json.